### PR TITLE
Miscellaneous fixes and add support to clerk.toml 

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,16 @@
         ],
         "comments": {
             "lineComment": "#"
+        },
+        "configurationDefaults": {
+            "[catala_en]": {
+                "editor.tabSize": 2,
+                "editor.insertSpaces": true
+            },
+            "[catala_fr]": {
+                "editor.tabSize": 2,
+                "editor.insertSpaces": true
+            }
         }
     },
     "scripts": {

--- a/server/src/dune
+++ b/server/src/dune
@@ -7,6 +7,7 @@
     lsp linol linol-lwt
     gen logs logs.fmt
     catala.driver
+    catala.clerk_config
     uri
   )
  (flags


### PR DESCRIPTION
This PR adds default indentation strategy and adds support for clerk.toml files in order to properly handle file includes.