### PR TITLE
Miscellaneous fixes

### DIFF
--- a/server/src/server.ml
+++ b/server/src/server.ml
@@ -150,6 +150,7 @@ class catala_lsp_server =
       Lwt.return_unit
 
     method! on_notif_doc_did_save ~notify_back d =
+      Lwt.cancel !current_thread;
       let { DidSaveTextDocumentParams.textDocument; _ } = d in
       self#on_doc ~notify_back textDocument.uri None
 

--- a/server/src/server.ml
+++ b/server/src/server.ml
@@ -105,7 +105,8 @@ class catala_lsp_server =
           ?inlayHintProvider:self#config_inlay_hints
           ?documentSymbolProvider:self#config_symbol
           ~textDocumentSync:(`TextDocumentSyncOptions sync_opts)
-          ~workspaceSymbolProvider:self#config_workspace_symbol ()
+          ~workspaceSymbolProvider:self#config_workspace_symbol
+          ~positionEncoding:PositionEncodingKind.UTF8 ()
         |> self#config_modify_capabilities
       in
       Lwt.return (InitializeResult.create ~capabilities ())


### PR DESCRIPTION
This PR fixes two bugs:
- a data-race issue that occurs when a document is changed and the document in saved just after;
- an issue with UTF16 encoded string which would be interpreted as UTF8 by breaking the consistency of internal buffers maintained by linol.