### PR TITLE
Rework code formatting glue to fix issue on large files

### DIFF
--- a/server/src/server.ml
+++ b/server/src/server.ml
@@ -410,7 +410,16 @@ class catala_lsp_server =
         Log.warn (fun m ->
             m "cannot find document content of document %s" doc_path);
         Lwt.return_none
-      | Some { content = doc_content; _ } ->
+      | Some { content = doc_content; _ } -> (
         let (_f : State.file) = self#use_or_process_file doc_path in
-        Utils.try_format_document ~notify_back ~doc_content ~doc_path
+        let* r =
+          Utils.try_format_document ~notify_back ~doc_content ~doc_path
+        in
+        match r with
+        | None ->
+          Log.info (fun m -> m "failed to format document");
+          Lwt.return_none
+        | Some r ->
+          Log.info (fun m -> m "document formatting done");
+          Lwt.return_some r)
   end


### PR DESCRIPTION
This PR fixes an issue where the external call to `catala-format` would fail on large files.
This is due to a concurrency issue that only occurs when pipe communication with an external process gets clogged.