### PR TITLE
Improve jump-to references 

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,6 @@
   "engines": {
     "vscode": "^1.86.0"
   },
-  "activationEvents": [
-    "onLanguage:catala_en",
-    "onLanguage:catala_fr"
-  ],
   "main": "./dist/extension.js",
   "contributes": {
     "configuration": {

--- a/server/src/jump.ml
+++ b/server/src/jump.ml
@@ -155,6 +155,10 @@ let populate_enum_inject
   match enum_decl_opt with
   | None -> m
   | Some (enum_decl, (enum_decl_typ, _vis)) -> (
+    let typ =
+      let pos_decl = Mark.get (EnumName.get_info enum_decl) in
+      Mark.add pos_decl (Shared_ast.TEnum enum_decl)
+    in
     (* Add enum reference *)
     let m =
       if enum_decl = enum_name then
@@ -165,10 +169,6 @@ let populate_enum_inject
       else
         let name = EnumName.to_string enum_name in
         let pos = Mark.get (EnumName.get_info enum_name) in
-        let typ =
-          let pos_decl = Mark.get (EnumName.get_info enum_decl) in
-          Mark.add pos_decl (Shared_ast.TEnum enum_decl)
-        in
         let hash = Hashtbl.hash (EnumName.get_info enum_decl) in
         let var = Usage { name; hash; typ } in
         PMap.add pos var m
@@ -178,7 +178,7 @@ let populate_enum_inject
       (EnumConstructor.Map.bindings enum_decl_typ)
     |> function
     | None -> m
-    | Some (enum_constr_decl, typ) ->
+    | Some (enum_constr_decl, _typ) ->
       let name = EnumConstructor.to_string cons in
       let hash = hash_info (module EnumConstructor) enum_constr_decl in
       let var = Usage { name; hash; typ } in

--- a/server/src/jump.ml
+++ b/server/src/jump.ml
@@ -170,17 +170,7 @@ let traverse_scope_sig scope m : var PMap.t =
       let pos = snd (ScopeVar.get_info scope_var) in
       let hash = hash_info (module ScopeVar) scope_var in
       let var = Declaration { name; hash; typ = var_ty.svar_out_ty } in
-      let var_typ_name = "typ:" ^ name in
-      let typ =
-        Declaration
-          {
-            name = var_typ_name;
-            hash = Hashtbl.hash (var_typ_name, Mark.get var_ty.svar_out_ty);
-            typ = var_ty.svar_out_ty;
-          }
-      in
-      let m = PMap.add pos var m in
-      PMap.add (Mark.get var_ty.svar_out_ty) typ m)
+      PMap.add pos var m)
     scope.scope_sig m
 
 let traverse_scope ctx (scope : typed scope_decl) m : var PMap.t =

--- a/server/src/server.ml
+++ b/server/src/server.ml
@@ -76,6 +76,7 @@ class catala_lsp_server =
     method private config_workspace_symbol = `Bool true
     method private config_declaration = Some (`Bool true)
     method private config_references = Some (`Bool true)
+    method private config_type_definition = Some (`Bool true)
 
     method! config_sync_opts =
       (* configure how sync happens *)
@@ -119,7 +120,8 @@ class catala_lsp_server =
           ?inlayHintProvider:self#config_inlay_hints
           ?documentSymbolProvider:self#config_symbol
           ~textDocumentSync:(`TextDocumentSyncOptions sync_opts)
-          ~workspaceSymbolProvider:self#config_workspace_symbol ()
+          ~workspaceSymbolProvider:self#config_workspace_symbol
+          ?typeDefinitionProvider:self#config_type_definition ()
         |> self#config_modify_capabilities
       in
       Lwt.return (InitializeResult.create ~capabilities ())
@@ -200,6 +202,9 @@ class catala_lsp_server =
             ~pos:params.position ()
         | TextDocumentReferences (params : ReferenceParams.t) ->
           self#on_req_references ~notify_back ~uri:params.textDocument.uri
+            ~pos:params.position ()
+        | TextDocumentTypeDefinition (params : TypeDefinitionParams.t) ->
+          self#on_req_type_definition ~notify_back ~uri:params.textDocument.uri
             ~pos:params.position ()
         | WorkspaceSymbol params ->
           self#on_req_workspace_symbol ~notify_back params
@@ -361,6 +366,20 @@ class catala_lsp_server =
         let typ_s = Format.asprintf "%a" Format.pp_print_text typ_s in
         let mc = MarkupContent.create ~kind:PlainText ~value:typ_s in
         Lwt.return_some (Hover.create ~contents:(`MarkupContent mc) ())
+
+    method private on_req_type_definition
+        ~notify_back:_
+        ~(uri : Lsp.Uri.t)
+        ~(pos : Position.t)
+        ()
+        : Locations.t option Lwt.t =
+      let f = self#use_or_process_file (DocumentUri.to_path uri) in
+      match State.lookup_type_definition f pos with
+      | None -> Lwt.return_none
+      | Some (file, range) ->
+        let uri = DocumentUri.of_path file in
+        let loc = Lsp.Types.Location.create ~range ~uri in
+        Lwt.return_some (`Location [loc])
 
     method! on_req_symbol
         ~notify_back:_

--- a/server/src/server.ml
+++ b/server/src/server.ml
@@ -358,9 +358,7 @@ class catala_lsp_server =
       match State.lookup_type f pos with
       | None -> Lwt.return_none
       | Some typ_s ->
-        let typ_s =
-          Format.asprintf "@[<hov 2>Type:@\n%a@]" Format.pp_print_text typ_s
-        in
+        let typ_s = Format.asprintf "%a" Format.pp_print_text typ_s in
         let mc = MarkupContent.create ~kind:PlainText ~value:typ_s in
         Lwt.return_some (Hover.create ~contents:(`MarkupContent mc) ())
 

--- a/server/src/state.ml
+++ b/server/src/state.ml
@@ -144,8 +144,7 @@ let lookup_document_symbols file =
   | Some variables ->
     List.filter_map
       (fun (p, v) ->
-        if file.uri = Catala_utils.Pos.get_file p then
-          Some (Jump.var_to_symbol p v)
+        if file.uri = Catala_utils.Pos.get_file p then Jump.var_to_symbol p v
         else None)
       (Jump.PMap.bindings variables)
 
@@ -160,7 +159,7 @@ let lookup_project_symbols all_files =
       (Jump.PMap.union (fun _ l _ -> Some l))
       Jump.PMap.empty all_tbls
   in
-  List.map
+  List.filter_map
     (fun (p, v) -> Jump.var_to_symbol p v)
     (Jump.PMap.bindings all_variables)
 

--- a/server/src/state.ml
+++ b/server/src/state.ml
@@ -132,7 +132,14 @@ let lookup_type f p =
   let* jt = f.jump_table in
   let* typ = Jump.lookup_type jt p in
   let* prg = f.scopelang_prg in
-  let typ_s = Format.asprintf "%a" (Shared_ast.Print.typ prg.program_ctx) typ in
+  let typ_s =
+    match Catala_utils.Mark.remove typ with
+    | TStruct struct_name ->
+      Format.asprintf "Struct %s" (Shared_ast.StructName.to_string struct_name)
+    | TEnum enum_name ->
+      Format.asprintf "Enum %s" (Shared_ast.EnumName.to_string enum_name)
+    | _ -> Format.asprintf "%a" (Shared_ast.Print.typ prg.program_ctx) typ
+  in
   Some typ_s
 
 let lookup_document_symbols file =

--- a/server/src/state.ml
+++ b/server/src/state.ml
@@ -142,6 +142,21 @@ let lookup_type f p =
   in
   Some typ_s
 
+let lookup_type_definition f p =
+  let p = Utils.(lsp_range p p |> pos_of_range f.uri) in
+  let ( let* ) = Option.bind in
+  let* jt = f.jump_table in
+  let* typ, _pos = Jump.lookup_type jt p in
+  let open Shared_ast in
+  match typ with
+  | TStruct s ->
+    let _, pos = StructName.get_info s in
+    Some (to_position pos)
+  | TEnum e ->
+    let _, pos = EnumName.get_info e in
+    Some (to_position pos)
+  | _ -> None
+
 let lookup_document_symbols file =
   let variables =
     Option.bind file.jump_table @@ fun tbl -> Some tbl.variables

--- a/syntaxes/en.xml
+++ b/syntaxes/en.xml
@@ -200,7 +200,7 @@
         </dict>
         <dict>
           <key>match</key>
-          <string>\b(scope|depends\s+on|declaration|includes|list\s+of|content|optional|structure|enumeration|context|input|output|internal|rule|under\s+condition|condition|data|consequence|fulfilled|equals|assertion|definition|state|label|exception|anything)\b</string>
+          <string>\b(scope|depends\s+on|declaration|includes|list\s+of|content\s+of|content|optional|structure|enumeration|context|input|output|internal|rule|under\s+condition|condition|data|consequence|fulfilled|equals|assertion|definition|state|label|exception|anything|list\s+empty|is\s+maximum|is\s+minimum|minimum\s+of|maximum\s+of)\b</string>
           <key>name</key>
           <string>keyword.other.catala_en</string>
         </dict>

--- a/syntaxes/fr.xml
+++ b/syntaxes/fr.xml
@@ -200,7 +200,7 @@
         </dict>
         <dict>
           <key>match</key>
-          <string>\b(champ\s+d&apos;application|si\s+et\s+seulement\s+si|dépend\s+de|déclaration|inclus|liste\s+de|contenu|optionnel|structure|énumération|contexte|entrée|résultat|interne|règle|sous\s+condition|condition|donnée|conséquence|rempli|égal\s+à|assertion|définition|état|étiquette|exception|n'importe\s+quel)\b</string>
+          <string>\b(champ\s+d&apos;application|si\s+et\s+seulement\s+si|dépend\s+de|déclaration|inclus|liste\s+de|contenu\s+de|contenu|optionnel|structure|énumération|contexte|entrée|résultat|interne|règle|sous\s+condition|condition|donnée|conséquence|rempli|égal\s+à|assertion|définition|état|étiquette|exception|n'importe\s+quel|liste\s+vide|est\s+maximum|est\s+minimum|minimum\s+de|maximum\s+de)\b</string>
           <key>name</key>
           <string>keyword.other.catala_fr</string>
         </dict>


### PR DESCRIPTION
This PR adds several AST traversals that were missing and, hence, didn't provide jump-to locations for some expressions.

In particular, structures and enums, as well as their inner fields, are now fully handled. It is now also well referenced and hover pop-ups are less confusing.

