### PR TITLE
Display an error message when catala-lsp is not found

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,14 @@
         "@types/react-dom": "^18.3.0",
         "@types/vscode-webview": "^1.57.5",
         "@vscode/codicons": "^0.0.36",
+        "command-exists": "^1.2.9",
         "p-queue": "^8.0.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "vscode-languageclient": "^8.0.2"
       },
       "devDependencies": {
+        "@types/command-exists": "^1.2.3",
         "@types/mocha": "^10.0.6",
         "@types/node": "^18.11.18",
         "@types/vscode": "^1.86.0",
@@ -370,6 +372,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@types/command-exists": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-exists/-/command-exists-1.2.3.tgz",
+      "integrity": "sha512-PpbaE2XWLaWYboXD6k70TcXO/OdOyyRFq5TVpmlUELNxdkkmXU9fkImNosmXU1DtsNrqdUgWd/nJQYXgwmtdXQ==",
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",
@@ -1587,6 +1595,11 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/command-exists": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
     },
     "node_modules/commander": {
       "version": "12.1.0",

--- a/package.json
+++ b/package.json
@@ -104,12 +104,14 @@
     "@types/react-dom": "^18.3.0",
     "@types/vscode-webview": "^1.57.5",
     "@vscode/codicons": "^0.0.36",
+    "command-exists": "^1.2.9",
     "p-queue": "^8.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "vscode-languageclient": "^8.0.2"
   },
   "devDependencies": {
+    "@types/command-exists": "^1.2.3",
     "@types/mocha": "^10.0.6",
     "@types/node": "^18.11.18",
     "@types/vscode": "^1.86.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,35 +1,51 @@
-import { type ExtensionContext } from 'vscode';
+import * as vscode from 'vscode';
 import type { Executable } from 'vscode-languageclient/node';
 import { LanguageClient } from 'vscode-languageclient/node';
 import * as path from 'path';
 
 import { TestCaseEditorProvider } from './testCaseEditor';
 import { logger } from './logger';
+import * as fs from 'fs';
+import * as cmd_exists from 'command-exists';
 
 let client: LanguageClient;
 
-export function activate(context: ExtensionContext): void {
+export function activate(context: vscode.ExtensionContext): void {
   logger.show();
 
-  const cmd = context.asAbsolutePath(
+  const catala_binary = 'catala-lsp';
+
+  const local_path = context.asAbsolutePath(
     path.join('server', '_build', 'default', 'src', 'main.exe')
   );
 
-  const run: Executable = { command: cmd };
+  const is_binary_in_path = cmd_exists.sync(catala_binary);
+  const is_local_binary_present = fs.existsSync(local_path);
 
-  client = new LanguageClient(
-    cmd,
-    'Catala Language Server Protocol',
-    { run, debug: run },
-    {
-      documentSelector: [
-        { scheme: 'file', language: 'catala_en', pattern: '**/*.catala_en' },
-        { scheme: 'file', language: 'catala_fr', pattern: '**/*.catala_fr' },
-      ],
+  if (!is_binary_in_path && !is_local_binary_present) {
+    const err_msg =
+      'Catala LSP not found on the system: please refer to the installation procedure https://github.com/CatalaLang/catala-language-server/?tab=readme-ov-file#installation';
+    vscode.window.showErrorMessage(err_msg);
+  } else {
+    let cmd;
+    if (is_local_binary_present) {
+      cmd = local_path;
+    } else {
+      cmd = catala_binary;
     }
-  );
-
-  client.start();
+    const run: Executable = { command: cmd };
+    client = new LanguageClient(
+      cmd,
+      'Catala Language Server Protocol',
+      { run, debug: run },
+      {
+        documentSelector: [
+          { scheme: 'file', language: 'catala_en', pattern: '**/*.catala_en' },
+          { scheme: 'file', language: 'catala_fr', pattern: '**/*.catala_fr' },
+        ],
+      }
+    );
+  }
 
   // Always register the custom editor provider
   context.subscriptions.push(TestCaseEditorProvider.register(context));


### PR DESCRIPTION
This PR adds a check that tests if the catala-lsp is found either in path or locally and display an error message if neither are available.

This will be useful towards the packaging of the extension.