### PR TITLE
Fix issue in entrypoint script

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,6 +45,8 @@ export function activate(context: vscode.ExtensionContext): void {
         ],
       }
     );
+
+    client.start();
   }
 
   // Always register the custom editor provider


### PR DESCRIPTION
I apparently forgot to call `client.start()`.