### PR TITLE
Miscellaneous fixes

### DIFF
--- a/server/src/state.ml
+++ b/server/src/state.ml
@@ -447,7 +447,18 @@ let process_document ?contents (uri : string) : t =
         Log.debug (fun m ->
             m "caught (CompilerError %t)" (fun ppf ->
                 Catala_utils.Message.Content.emit ~ppf er Error))
-      | _ -> ());
+      | e ->
+        on_error
+          {
+            Message.kind = Generic;
+            message =
+              (fun fmt ->
+                Format.fprintf fmt
+                  "Generic exception while processing document: %s"
+                  (Printexc.to_string e));
+            pos = None;
+            suggestion = None;
+          });
       Log.info (fun m ->
           m "caught generic exception: %s (%d diagnostics to send)"
             (Printexc.to_string e) (List.length !l));

--- a/server/src/state.ml
+++ b/server/src/state.ml
@@ -280,9 +280,11 @@ let load_module_interfaces config_dir includes program =
               (err_req_pos (Mark.get use.Surface.Ast.mod_use_name :: req_chain))
             "Circular module dependency"
         | None ->
+          (* Some file paths are absolute, we normalize them wrt to the config
+             directory *)
+          let f_path = Utils.join_paths config_dir f in
           let intf =
-            Surface.Parser_driver.load_interface
-              (Global.FileName File.(config_dir / f))
+            Surface.Parser_driver.load_interface (Global.FileName f_path)
           in
           let modname = ModuleName.fresh intf.intf_modname.module_name in
           let seen = File.Map.add f None seen in

--- a/server/src/utils.ml
+++ b/server/src/utils.ml
@@ -169,3 +169,17 @@ let try_format_document ~notify_back ~doc_content ~doc_path =
           (Printexc.to_string exn)
       in
       Lwt.return_none)
+
+let join_paths ?(abs = true) dir path =
+  let open File in
+  let dir = path_to_list dir in
+  let path = path_to_list path in
+  let rec loop acc = function
+    | [], [] -> acc
+    | r, [] | [], r -> List.rev_append r acc
+    | h :: t, (h' :: t' as r) ->
+      if h <> h' then loop (h :: acc) (t, r) else loop (h :: acc) (t, t')
+  in
+  loop [] (dir, path)
+  |> List.rev
+  |> List.fold_left ( / ) (if abs then "/" else "")


### PR DESCRIPTION
This PR contains several small fixes:
- Triggers a generic error notification from unexpected triggered exceptions instead of failing silently;
- Fixes module paths handling as some would be absolute and some relatives;
- Fixes external modules: a bug in scopelang raises an unexpected exception, we avoid that by not translating it to scopelang. If the external module is the current document, it will be skipped, however references and jumping to this module is functional from other files.