### PR TITLE
Fix `vscode-test` setup and add CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up OCaml
+      uses: ocaml/setup-ocaml@v3
+      with:
+        ocaml-compiler: 5.0.x
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      run: |
+        opam pin add --dev-repo catala
+        opam install dune
+        opam install . --deps-only --with-test
+        npm ci
+
+    - name: Build project
+      run: |
+        opam exec -- dune build
+        opam exec -- dune install
+        npm run compile
+
+    - name: Run tests
+      run: xvfb-run -a npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up OCaml
       uses: ocaml/setup-ocaml@v3
@@ -19,7 +19,7 @@ jobs:
         ocaml-compiler: 5.0.x
 
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '20'
 

--- a/catala-lsp.opam
+++ b/catala-lsp.opam
@@ -13,6 +13,8 @@ depends: [
   "uri"
   "linol"     { = "dev" }
   "linol-lwt" { = "dev" }
+  "atdgen" { build }
+  "atdgen-runtime"
 ]
 pin-depends: [
   ["catala.dev" "git+https://github.com/CatalaLang/catala#lsp-compat"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "catala-vscode-extension",
-  "version": "0.0.1",
+  "name": "catala",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "catala-vscode-extension",
-      "version": "0.0.1",
+      "name": "catala",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/react": "^18.3.3",
@@ -15,7 +15,7 @@
         "@vscode/codicons": "^0.0.36",
         "command-exists": "^1.2.9",
         "microdiff": "^1.4.0",
-        "p-queue": "^8.0.1",
+        "p-queue": "^6.6.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "vscode-languageclient": "^8.0.2"
@@ -1968,6 +1968,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/events": {
@@ -3646,6 +3647,15 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -3677,31 +3687,37 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.0.1.tgz",
-      "integrity": "sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
       "license": "MIT",
       "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "p-timeout": "^6.1.2"
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/p-timeout": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.2.tgz",
-      "integrity": "sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
       "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
+      "dependencies": {
+        "p-finally": "^1.0.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@vscode/codicons": "^0.0.36",
     "command-exists": "^1.2.9",
     "microdiff": "^1.4.0",
-    "p-queue": "^8.0.1",
+    "p-queue": "^6.6.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "vscode-languageclient": "^8.0.2"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run package",
-    "compile": "dune build @lsp; webpack --mode development",
+    "compile": "opam exec -- dune build @lsp; webpack --mode development",
     "test": "tsc && vscode-test",
     "format": "prettier --write .",
     "lint": "eslint . --ext .js,.ts",


### PR DESCRIPTION
The current `vscode-test` stub was broken by the use of `p-queue` (promise queue, a dependency when implementing the "run test" feature).

The current p-queue is not compatible with commonjs2 builds, which we use.

This PR pins p-queue to 6.6.2, which is the last version that supports a commonjs build, and adds a CI job that runs `vscode-test` 

Ultimately we should use ESM for packaging our plugin but the support for this in vscode is still not yet completely mature (?) -- see for instance https://github.com/microsoft/vscode/issues/130367 and https://code.visualstudio.com/updates/v1_94#_esm-is-shipping-for-vs-code