### PR TITLE
Replace naive position map with better data structure

### DIFF
--- a/server/src/jump.ml
+++ b/server/src/jump.ml
@@ -218,7 +218,15 @@ let traverse_expr (ctx : Desugared.Name_resolution.context) e m =
         (* Don't recurse when the next expression is nil *)
         acc
       else f e acc
-    | _ -> Expr.shallow_fold f e acc
+    | _ ->
+      (* TODO: EAbs's binders do not carry a position, we cannot index them as
+         of right now. Possible solutions:
+
+         - Add their position to Bindlib's vars
+
+         - Carry them over from surface and resolve them when we get sufficient
+         informations *)
+      Expr.shallow_fold f e acc
   in
   Expr.shallow_fold f e m
 

--- a/server/src/jump.ml
+++ b/server/src/jump.ml
@@ -182,8 +182,13 @@ let traverse_expr (ctx : Desugared.Name_resolution.context) e m =
   let rec f e acc =
     let (Typed { pos; ty = typ }) = Mark.get e in
     match Mark.remove e with
-    | EDefault { excepts; just = _; cons } ->
-      (* just have (useless?) conflicting positions *)
+    | EDefault { excepts; just; cons } ->
+      let acc =
+        match Mark.remove just with
+        (* ignore boolean conditions *)
+        | ELit (LBool _) -> acc
+        | _ -> f just acc
+      in
       let lfold x acc = List.fold_left (fun acc x -> f x acc) acc x in
       acc |> lfold excepts |> f cons
     | ELit _l -> PMap.add pos (Literal typ) acc

--- a/server/src/jump.ml
+++ b/server/src/jump.ml
@@ -18,7 +18,6 @@ open Catala_utils
 open Shared_ast
 open Utils
 open Scopelang.Ast
-module PMap = Position_map
 
 let hash_info (type a) (module M : Uid.Id with type t = a) (v : a) : int =
   Hashtbl.hash (M.get_info v)
@@ -42,9 +41,6 @@ type var =
   | Usage of jump
   | Literal of typ
 
-type variables = var PMap.pmap
-type t = { variables : variables; lookup_table : lookup_entry LTable.t }
-
 let pp_var ppf =
   let open Format in
   function
@@ -53,6 +49,15 @@ let pp_var ppf =
   | Declaration { name; hash; _ } -> fprintf ppf "declaration: %s#%d" name hash
   | Usage { name; hash; _ } -> fprintf ppf "usage: %s#%d" name hash
   | Literal typ -> fprintf ppf "literal: %a" Print.typ_debug typ
+
+module PMap = Position_map.Make (struct
+  type t = var
+
+  let format = pp_var
+end)
+
+type variables = PMap.pmap
+type t = { variables : variables; lookup_table : lookup_entry LTable.t }
 
 let pp_table ppf { declaration; definitions; usages } =
   let open Format in
@@ -200,7 +205,7 @@ let traverse_expr (ctx : Desugared.Name_resolution.context) e m =
 let rec traverse_typ
     (ctx : Desugared.Name_resolution.context)
     ((typ, pos) : naked_typ * Pos.t)
-    m : var PMap.pmap =
+    m : PMap.pmap =
   match typ with
   | TStruct struct_name ->
     let name = StructName.to_string struct_name in
@@ -215,7 +220,7 @@ let rec traverse_typ
   | TOption typ | TArray typ | TDefault typ -> traverse_typ ctx typ m
   | TLit _ | TAny | TClosureEnv -> m
 
-let traverse_scope_def ctx (rule : typed rule) m : var PMap.pmap =
+let traverse_scope_def ctx (rule : typed rule) m : PMap.pmap =
   match rule with
   | ScopeVarDefinition { var; typ; io = _; e }
   | SubScopeVarDefinition { var; typ; var_within_origin_scope = _; e } ->
@@ -228,7 +233,7 @@ let traverse_scope_def ctx (rule : typed rule) m : var PMap.pmap =
     traverse_expr ctx e m
   | Assertion e -> traverse_expr ctx e m
 
-let traverse_scope_sig ctx scope m : var PMap.pmap =
+let traverse_scope_sig ctx scope m : PMap.pmap =
   ScopeVar.Map.fold
     (fun scope_var var_ty m ->
       let m = traverse_typ ctx var_ty.svar_out_ty m in
@@ -239,7 +244,7 @@ let traverse_scope_sig ctx scope m : var PMap.pmap =
       PMap.add pos var m)
     scope.scope_sig m
 
-let traverse_scope ctx (scope : typed scope_decl) m : var PMap.pmap =
+let traverse_scope ctx (scope : typed scope_decl) m : PMap.pmap =
   let m = traverse_scope_sig ctx scope m in
   List.fold_right (traverse_scope_def ctx) scope.scope_decl_rules m
 
@@ -247,7 +252,7 @@ let traverse_topdef
     ctx
     (topdef : TopdefName.t)
     ((e, typ, _vis) : typed expr * typ * visibility)
-    m : var PMap.pmap =
+    m : PMap.pmap =
   let name = TopdefName.to_string topdef in
   let topdef_pos = snd (TopdefName.get_info topdef) in
   let hash = Hashtbl.hash (TopdefName.get_info topdef) in
@@ -255,7 +260,7 @@ let traverse_topdef
   let m = PMap.add topdef_pos topdef m in
   traverse_expr ctx e m
 
-let traverse_ctx (ctx : Desugared.Name_resolution.context) m : var PMap.pmap =
+let traverse_ctx (ctx : Desugared.Name_resolution.context) m : PMap.pmap =
   let m =
     StructName.Map.fold
       (fun struct_name (fields, _vis) m ->
@@ -304,7 +309,7 @@ let traverse_ctx (ctx : Desugared.Name_resolution.context) m : var PMap.pmap =
 
 let traverse
     (ctx : Desugared.Name_resolution.context)
-    (prog : Shared_ast.typed Scopelang.Ast.program) : var PMap.pmap =
+    (prog : Shared_ast.typed Scopelang.Ast.program) : PMap.pmap =
   let m =
     ModuleName.Map.fold
       (fun _m_name decl_map acc ->

--- a/server/src/jump.ml
+++ b/server/src/jump.ml
@@ -182,6 +182,10 @@ let traverse_expr (ctx : Desugared.Name_resolution.context) e m =
   let rec f e acc =
     let (Typed { pos; ty = typ }) = Mark.get e in
     match Mark.remove e with
+    | EDefault { excepts; just = _; cons } ->
+      (* just have (useless?) conflicting positions *)
+      let lfold x acc = List.fold_left (fun acc x -> f x acc) acc x in
+      acc |> lfold excepts |> f cons
     | ELit _l -> PMap.add pos (Literal typ) acc
     | ELocation (ScopelangScopeVar { name; _ }) ->
       let (scope_var : ScopeVar.t), pos = name in

--- a/server/src/position_map.ml
+++ b/server/src/position_map.ml
@@ -1,0 +1,218 @@
+(* This file is part of the Catala compiler, a specification language for tax
+   and social benefits computation rules. Copyright (C) 2024 Inria, contributor:
+   Vincent Botbol <vincent.botbol@inria.fr>
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License. *)
+
+module Trie = struct
+  type 'a itv_node =
+    | Node of { itv : int * int; data : 'a; children : 'a trie }
+
+  and 'a trie = 'a itv_node list
+
+  type 'a t = 'a trie
+
+  let is_in (i, j) n = i <= n && n <= j
+  let ( let*? ) opt f = match opt with None -> None | Some v -> f v
+
+  let rec lookup i trie =
+    List.find_opt (fun (Node { itv; _ }) -> is_in itv i) trie
+    |> function
+    | None -> None
+    | Some (Node { children = []; data; _ }) -> Some data
+    | Some (Node { children; data; _ }) -> (
+      match lookup i children with None -> Some data | Some v -> Some v)
+
+  let compare_itv ((i, j) as itv) (i', j') =
+    if i = i' && j = j' then `Equal
+    else if j' < i then `Disjoint_left
+    else if i' > j then `Disjoint_right
+    else if i <= i' && j' <= j then `Subset
+    else if i' < i && j' > j then `Supset
+    else if is_in itv i' && j' > j then
+      `Left_inclusion
+        ((i', j) (* included part *), (j + 1, j') (* disjoint part *))
+    else (
+      assert (i > i' && is_in itv j');
+      `Right_inclusion
+        ((i', i - 1) (* disjoint part *), (i, j') (* included part *)))
+
+  let rec gather_children (Node { children; _ }) =
+    let fresh_children =
+      List.map (fun (Node node) -> Node { node with children = [] }) children
+    in
+    fresh_children @ List.concat_map gather_children children
+
+  let rec insert itv data trie =
+    let rec find_included_nodes acc = function
+      | [] -> List.rev acc, []
+      | (Node n as h) :: t -> (
+        match compare_itv itv n.itv with
+        | `Equal -> assert false
+        | `Subset -> find_included_nodes (h :: acc) t
+        | `Disjoint_right -> List.rev acc, t
+        | `Disjoint_left | `Supset | `Right_inclusion _ ->
+          (* by construction *) assert false
+        | `Left_inclusion (included_itv, disjoint_part) -> (
+          let included_node =
+            Node { n with itv = included_itv; children = [] }
+          in
+          let disjoint_node =
+            Node { n with itv = disjoint_part; children = [] }
+          in
+          let all_children = gather_children h in
+          (* Introduce quadratric behavior but shouldn't be impactful with our
+             use-case *)
+          let sub_trie =
+            List.fold_left
+              (fun trie (Node children) ->
+                insert children.itv children.data trie)
+              [included_node; disjoint_node]
+              all_children
+          in
+          match sub_trie with
+          | [included_node; disjoint_node] ->
+            List.rev (included_node :: acc), disjoint_node :: t
+          | _ -> assert false))
+    in
+    let rec loop acc itv : 'a trie -> 'a trie = function
+      | [] -> Node { itv; data; children = [] } :: acc |> List.rev
+      | (Node ({ itv = itv_p; children; _ } as node_r) as node) :: t as l -> (
+        match compare_itv itv_p itv with
+        | `Equal ->
+          (* We do not create equivalent nodes *)
+          List.rev_append (node :: acc) t
+        | `Disjoint_left ->
+          List.rev_append (Node { itv; data; children = [] } :: acc) l
+        | `Disjoint_right -> loop (node :: acc) itv t
+        | `Subset ->
+          let new_children = insert itv data children in
+          List.rev_append
+            (Node { node_r with children = new_children } :: acc)
+            t
+        | `Supset ->
+          let all_included_nodes, disjoint_nodes = find_included_nodes [] l in
+          let node = Node { itv; data; children = all_included_nodes } in
+          List.rev_append (node :: acc) disjoint_nodes
+        | `Left_inclusion (included_itv, disjoint_part) ->
+          let new_children = insert included_itv data children in
+          loop
+            (Node { node_r with children = new_children } :: acc)
+            disjoint_part t
+        | `Right_inclusion (disjoint_part, included_itv) ->
+          let acc = Node { itv = disjoint_part; data; children = [] } :: acc in
+          let new_children = insert included_itv data children in
+          List.rev_append
+            (Node { node_r with children = new_children } :: acc)
+            t)
+    in
+    loop [] itv trie
+end
+
+open Catala_utils
+module FileMap = Map.Make (String)
+
+module LineMap = Map.Make (struct
+  include Int
+
+  let format = Format.pp_print_int
+end)
+
+type 'a pmap = 'a Trie.t LineMap.t FileMap.t
+type 'a t = 'a pmap
+
+let ( -- ) i j = List.init (j - i + 1) (fun x -> i + x)
+
+let lines pos v =
+  let s = Pos.get_start_line pos in
+  let e = Pos.get_end_line pos in
+  let s_col = Pos.get_start_column pos in
+  let e_col = Pos.get_end_column pos in
+  if s = e then LineMap.singleton s ((s_col, e_col), v)
+  else
+    let s_itv = (s_col, max_int), v in
+    let e_itv = (0, e_col), v in
+    LineMap.of_list
+      ((s, s_itv)
+      :: (e, e_itv)
+      :: List.map (fun i -> i, ((0, max_int), v)) (s + 1 -- (e - 1)))
+
+let merge_tries _i trie trie' : 'a Trie.t option =
+  match trie, trie' with
+  | None, None -> None
+  | None, Some (itv, data) -> Some [Node { itv; data; children = [] }]
+  | Some trie, None -> Some trie
+  | Some trie, Some (itv, data) -> Some (Trie.insert itv data trie)
+
+let add pos data variables =
+  FileMap.update (Pos.get_file pos)
+    (function
+      | None ->
+        Some
+          (lines pos data
+          |> LineMap.map (fun (itv, data) ->
+                 [Trie.Node { itv; data; children = [] }]))
+      | Some im -> Some (LineMap.merge merge_tries im (lines pos data)))
+    variables
+
+let lookup pos pmap =
+  let ( let* ) = Option.bind in
+  (* we assume that pos's start/end lines, start/end column are equal *)
+  let* lmap = FileMap.find_opt (Pos.get_file pos) pmap in
+  let* trie = LineMap.find_opt (Pos.get_start_line pos) lmap in
+  Trie.lookup (Pos.get_start_column pos) trie
+
+let fold f pmap acc =
+  FileMap.fold
+    (fun file lmap acc ->
+      LineMap.fold
+        (fun line trie acc ->
+          let l = List.concat_map Trie.gather_children trie in
+          List.fold_left
+            (fun acc (Trie.Node { itv = i, j; data; _ }) ->
+              f (Pos.from_info file line line i j) data acc)
+            acc l)
+        lmap acc)
+    pmap acc
+
+let elements pmap = fold (fun pos var acc -> (pos, var) :: acc) pmap []
+
+let rec pp_node pp_data ppf (Trie.Node { itv = i, j; data; children }) =
+  let open Format in
+  let pp_d fmt i =
+    if i = max_int then fprintf fmt "EOL" else pp_print_int fmt i
+  in
+  match children with
+  | [] -> fprintf ppf "@[<h>(%a⟷%a): %a@]" pp_d i pp_d j pp_data data
+  | _ ->
+    fprintf ppf "@[<v 2>(%a⟷%a): %a@ %a@]" pp_d i pp_d j pp_data data
+      (pp_trie pp_data) children
+
+and pp_trie pp_data ppf tries =
+  let open Format in
+  fprintf ppf "@[<v>%a@]"
+    (pp_print_list ~pp_sep:pp_print_cut (pp_node pp_data))
+    tries
+
+let pp pp_elt ppf pmap =
+  let open Format in
+  let pp_lines ppf lmap =
+    fprintf ppf "@[<v 2>lines:@ %a@]"
+      (LineMap.format ~pp_sep:pp_print_cut (pp_trie pp_elt))
+      lmap
+  in
+  fprintf ppf "@[<v 2>variables:@ @[<v 2>%a@]@]"
+    (FileMap.format ~pp_sep:pp_print_cut pp_lines)
+    pmap
+
+let empty = FileMap.empty

--- a/server/src/server.ml
+++ b/server/src/server.ml
@@ -81,7 +81,6 @@ class catala_lsp_server =
     method! config_sync_opts =
       (* configure how sync happens *)
       let change = Lsp.Types.TextDocumentSyncKind.Incremental in
-      (* Lsp.Types.TextDocumentSyncKind.Full *)
       Lsp.Types.TextDocumentSyncOptions.create ~openClose:true ~change
         ~save:
           (`SaveOptions (Lsp.Types.SaveOptions.create ~includeText:false ()))

--- a/server/src/server.ml
+++ b/server/src/server.ml
@@ -73,7 +73,7 @@ class catala_lsp_server =
     method! config_definition = Some (`Bool true)
     method! config_hover = Some (`Bool true)
     method! config_symbol = Some (`Bool true)
-    method private config_workspace_symbol = `Bool true
+    method private config_workspace_symbol = `Bool false
     method private config_declaration = Some (`Bool true)
     method private config_references = Some (`Bool true)
     method private config_type_definition = Some (`Bool true)
@@ -206,8 +206,6 @@ class catala_lsp_server =
         | TextDocumentTypeDefinition (params : TypeDefinitionParams.t) ->
           self#on_req_type_definition ~notify_back ~uri:params.textDocument.uri
             ~pos:params.position ()
-        | WorkspaceSymbol params ->
-          self#on_req_workspace_symbol ~notify_back params
         | TextDocumentFormatting params ->
           self#on_req_document_formatting ~notify_back params
         | _ -> super#on_request_unhandled ~notify_back ~id r
@@ -395,25 +393,6 @@ class catala_lsp_server =
       let f = self#use_or_process_file (DocumentUri.to_path uri) in
       let all_symbols = State.lookup_document_symbols f in
       Lwt.return_some (`SymbolInformation all_symbols)
-
-    method private on_req_workspace_symbol
-        ~notify_back:_
-        { Linol_lwt.WorkspaceSymbolParams.query; _ }
-        : Linol_lwt.SymbolInformation.t list option Lwt.t =
-      let filter (symbol : SymbolInformation.t) =
-        match query with
-        | "" -> true
-        | query ->
-          let re = Re.str query |> Re.compile in
-          Re.execp re symbol.name
-      in
-      let all_symbols =
-        Hashtbl.to_seq_values buffers
-        |> List.of_seq
-        |> State.lookup_project_symbols
-        |> List.filter filter
-      in
-      Lwt.return_some all_symbols
 
     method private on_req_document_formatting
         ~notify_back

--- a/server/src/server.ml
+++ b/server/src/server.ml
@@ -362,10 +362,10 @@ class catala_lsp_server =
       let f = self#use_or_process_file (DocumentUri.to_path uri) in
       match State.lookup_type f pos with
       | None -> Lwt.return_none
-      | Some typ_s ->
+      | Some (range, typ_s) ->
         let typ_s = Format.asprintf "%a" Format.pp_print_text typ_s in
         let mc = MarkupContent.create ~kind:PlainText ~value:typ_s in
-        Lwt.return_some (Hover.create ~contents:(`MarkupContent mc) ())
+        Lwt.return_some (Hover.create ~range ~contents:(`MarkupContent mc) ())
 
     method private on_req_type_definition
         ~notify_back:_

--- a/server/src/state.ml
+++ b/server/src/state.ml
@@ -164,24 +164,10 @@ let lookup_document_symbols file =
   match variables with
   | None -> []
   | Some variables ->
-    List.filter_map
-      (fun (p, v) ->
-        if file.uri = Catala_utils.Pos.get_file p then Jump.var_to_symbol p v
-        else None)
-      (Jump.PMap.elements variables)
-
-let lookup_project_symbols all_files =
-  let all_variables =
-    let all_tbls =
-      List.filter_map
-        (fun f -> Option.bind f.jump_table @@ fun tbl -> Some tbl.variables)
-        all_files
-    in
-    List.fold_left
-      (fun acc pmap -> List.rev_append (Jump.PMap.elements pmap) acc)
-      [] all_tbls
-  in
-  List.filter_map (fun (p, v) -> Jump.var_to_symbol p v) all_variables
+    Jump.PMap.fold_on_file file.uri
+      (fun p v acc ->
+        match Jump.var_to_symbol p v with None -> acc | Some v -> v :: acc)
+      variables []
 
 let lookup_clerk_toml (path : string) =
   let from_dir = Filename.dirname path in

--- a/server/src/state.ml
+++ b/server/src/state.ml
@@ -168,7 +168,7 @@ let lookup_document_symbols file =
       (fun (p, v) ->
         if file.uri = Catala_utils.Pos.get_file p then Jump.var_to_symbol p v
         else None)
-      (Position_map.elements variables)
+      (Jump.PMap.elements variables)
 
 let lookup_project_symbols all_files =
   let all_variables =
@@ -178,7 +178,7 @@ let lookup_project_symbols all_files =
         all_files
     in
     List.fold_left
-      (fun acc pmap -> List.rev_append (Position_map.elements pmap) acc)
+      (fun acc pmap -> List.rev_append (Jump.PMap.elements pmap) acc)
       [] all_tbls
   in
   List.filter_map (fun (p, v) -> Jump.var_to_symbol p v) all_variables

--- a/server/src/state.ml
+++ b/server/src/state.ml
@@ -130,7 +130,7 @@ let lookup_type f p =
   let p = Utils.(lsp_range p p |> pos_of_range f.uri) in
   let ( let* ) = Option.bind in
   let* jt = f.jump_table in
-  let* typ = Jump.lookup_type jt p in
+  let* r, typ = Jump.lookup_type jt p in
   let* prg = f.scopelang_prg in
   let typ_s =
     match Catala_utils.Mark.remove typ with
@@ -140,13 +140,13 @@ let lookup_type f p =
       Format.asprintf "Enum %s" (Shared_ast.EnumName.to_string enum_name)
     | _ -> Format.asprintf "%a" (Shared_ast.Print.typ prg.program_ctx) typ
   in
-  Some typ_s
+  Some (r, typ_s)
 
 let lookup_type_definition f p =
   let p = Utils.(lsp_range p p |> pos_of_range f.uri) in
   let ( let* ) = Option.bind in
   let* jt = f.jump_table in
-  let* typ, _pos = Jump.lookup_type jt p in
+  let* _r, (typ, _pos) = Jump.lookup_type jt p in
   let open Shared_ast in
   match typ with
   | TStruct s ->

--- a/server/src/state.ml
+++ b/server/src/state.ml
@@ -168,7 +168,7 @@ let lookup_document_symbols file =
       (fun (p, v) ->
         if file.uri = Catala_utils.Pos.get_file p then Jump.var_to_symbol p v
         else None)
-      (Jump.PMap.bindings variables)
+      (Position_map.elements variables)
 
 let lookup_project_symbols all_files =
   let all_variables =
@@ -178,12 +178,10 @@ let lookup_project_symbols all_files =
         all_files
     in
     List.fold_left
-      (Jump.PMap.union (fun _ l _ -> Some l))
-      Jump.PMap.empty all_tbls
+      (fun acc pmap -> List.rev_append (Position_map.elements pmap) acc)
+      [] all_tbls
   in
-  List.filter_map
-    (fun (p, v) -> Jump.var_to_symbol p v)
-    (Jump.PMap.bindings all_variables)
+  List.filter_map (fun (p, v) -> Jump.var_to_symbol p v) all_variables
 
 let lookup_clerk_toml (path : string) =
   let from_dir = Filename.dirname path in

--- a/server/src/utils.ml
+++ b/server/src/utils.ml
@@ -17,6 +17,10 @@
 open Lsp.Types
 open Catala_utils
 
+let pp_opt pp fmt =
+  let open Format in
+  function None -> fprintf fmt "<none>" | Some v -> fprintf fmt "%a" pp v
+
 let is_included (p : Pos.t) p' =
   (* true if p is included in p' *)
   Pos.get_file p = Pos.get_file p'


### PR DESCRIPTION
This PR removes the naive map of position that was used to lookup types/declarations and replaces it with a better data-structure similar to patricia tries that uses ranges as prefixes.

~WIP: the new structure uncovered strange inconsistencies that we silently ignored and needs to be addressed before merging this work.~

Edit: The PR is now in a good shape and imo ready to be merged. In particular, looking up declarations/references/hovering now works much better.