### PR TITLE
Correctly handle lambda binders

### DIFF
--- a/server/src/position_map.ml
+++ b/server/src/position_map.ml
@@ -202,12 +202,14 @@ module Make (D : Data) = struct
     (li, i), (lj, j)
 
   let add pos data variables =
-    let itv = pos_to_itv pos in
-    FileMap.update (Pos.get_file pos)
-      (function
-        | None -> Some [Trie.Node { itv; data; children = [] }]
-        | Some trie -> Some (Trie.insert itv data trie))
-      variables
+    if pos = Pos.no_pos then variables
+    else
+      let itv = pos_to_itv pos in
+      FileMap.update (Pos.get_file pos)
+        (function
+          | None -> Some [Trie.Node { itv; data; children = [] }]
+          | Some trie -> Some (Trie.insert itv data trie))
+        variables
 
   let lookup pos pmap =
     let ( let* ) = Option.bind in


### PR DESCRIPTION
This PR is  a follow up of https://github.com/CatalaLang/catala/pull/734 that needs to be merged beforehand.
It adds the support for lambda binders that weren't considered before which would leave holes in the "jump-to" and hovering over expressions.