### PR TITLE
Keep around the latest valid program and jump table

### DIFF
--- a/server/src/server.ml
+++ b/server/src/server.ml
@@ -129,7 +129,8 @@ class catala_lsp_server =
     val mutable prelude = []
 
     method private process_and_update_file ?contents uri =
-      let f = State.process_document ?contents uri in
+      let previous_file = Hashtbl.find_opt buffers uri in
+      let f = State.process_document ?previous_file ?contents uri in
       Hashtbl.replace buffers uri f;
       f
 


### PR DESCRIPTION
This PR maintains the latest valid context of a program. 

This fixes the situation where you are not able to query anything while you're trying to develop and your current buffer is in an invalid state (syntactically or semantically). With this patch you are still able to hover & lookup definitions/declarations.

However, some positions may become inconsistent but (I believe that) the benefits outweigh this issue. This will be tackled later on when the document processing gets refactored.