### PR TITLE
Multi language test generation

### DIFF
--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -6,8 +6,9 @@ export function getDefaultValue(typ: Typ): RuntimeValue {
     case 'TBool':
       return { kind: 'Bool', value: false };
     case 'TInt':
-    case 'TMoney':
       return { kind: 'Integer', value: 0 };
+    case 'TMoney':
+      return { kind: 'Money', value: 0 };
     case 'TRat':
       return { kind: 'Decimal', value: 0 };
     case 'TDate': {

--- a/test-case-parser/examples/francais.catala_fr
+++ b/test-case-parser/examples/francais.catala_fr
@@ -1,0 +1,20 @@
+> Module Francais
+
+```catala-metadata
+déclaration champ d'application TestFrançais:
+  entrée durée_promotion contenu durée
+  entrée début_promotion contenu date
+  entrée jour_achat contenu date
+  entrée prix contenu argent
+  entrée taux_promo contenu décimal
+  résultat prix_final contenu argent
+```
+
+```catala
+champ d'application TestFrançais:
+  définition prix_final égal à
+    si jour_achat < début_promotion
+      ou jour_achat > début_promotion + durée_promotion alors
+      prix
+    sinon prix * (1,0 - taux_promo)
+```

--- a/test-case-parser/examples/test_case_french.catala_fr
+++ b/test-case-parser/examples/test_case_french.catala_fr
@@ -1,0 +1,14 @@
+> Usage de Francais
+
+```catala
+déclaration champ d'application French_test:
+  résultat test_francais champ d'application Francais.TestFrançais
+  
+champ d'application French_test:
+  définition test_francais.durée_promotion égal à 7 jour
+  définition test_francais.début_promotion égal à |2024-01-07|
+  définition test_francais.jour_achat égal à |2024-01-10|
+  définition test_francais.prix égal à 100,00 €
+  définition test_francais.taux_promo égal à 0,2
+  assertion (test_francais.prix_final = 80,00 €)
+```


### PR DESCRIPTION
This will parametrize the test generator (that emits catala code from the ATD representation of the test structure) to emit either french or english sources, according to the original source language.