### PR TITLE
Add path configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,16 @@
           "type": "boolean",
           "default": false,
           "description": "Enable the custom test case editor for Catala test files"
+        },
+        "catala.lspServerPath": {
+          "type": "string",
+          "default": null,
+          "description": "Custom path to the `catala-lsp` executable"
+        },
+        "catala.catalaFormatPath": {
+          "type": "string",
+          "default": null,
+          "description": "Custom path to the `catala-format` executable"
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,12 @@ import * as cmd_exists from 'command-exists';
 let client: LanguageClient;
 
 export function activate(context: vscode.ExtensionContext): void {
+  const lsp_server_config_path = vscode.workspace
+    .getConfiguration('catala')
+    .get<string>('lspServerPath');
+  const is_binary_path_configured =
+    lsp_server_config_path != undefined && lsp_server_config_path != '';
+
   const local_path = context.asAbsolutePath(
     path.join('_build', 'default', 'server', 'src', 'main.exe')
   );
@@ -18,6 +24,18 @@ export function activate(context: vscode.ExtensionContext): void {
   let lsp_binary = lsp_binary_prefix;
 
   const is_local_binary_present = fs.existsSync(local_path);
+
+  const configured_binary_exists =
+    is_binary_path_configured && fs.existsSync(lsp_server_config_path!);
+  const is_configured_binary_present = configured_binary_exists;
+  if (is_binary_path_configured && !configured_binary_exists) {
+    vscode.window.showErrorMessage(
+      "Configured LSP path (catala.lspServerPath): '" +
+        lsp_server_config_path +
+        "' not found. Using default values..."
+    );
+  }
+
   let is_binary_in_path = false;
   if (cmd_exists.sync(lsp_binary_prefix)) {
     is_binary_in_path = true;
@@ -26,13 +44,19 @@ export function activate(context: vscode.ExtensionContext): void {
     is_binary_in_path = cmd_exists.sync(lsp_binary);
   }
 
-  if (!is_binary_in_path && !is_local_binary_present) {
+  if (
+    !is_binary_in_path &&
+    !is_local_binary_present &&
+    !is_configured_binary_present
+  ) {
     const err_msg =
       'Catala LSP not found on the system: please refer to the installation procedure https://github.com/CatalaLang/catala-language-server/?tab=readme-ov-file#installation';
     vscode.window.showErrorMessage(err_msg);
   } else {
     let cmd;
-    if (is_local_binary_present) {
+    if (is_configured_binary_present) {
+      cmd = lsp_server_config_path!;
+    } else if (is_local_binary_present) {
       cmd = local_path;
     } else {
       cmd = lsp_binary;


### PR DESCRIPTION
This PR adds two vscode configuration entries:
- catala.catalaFormatPath
- catala.lspServerPath

which allows the user to harcode path to the respective executables in order to bypass OS-related "limitations".