### PR TITLE
workaround to avoid the double-open problem: set the priority to 'opt…

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
           {
             "filenamePattern": "*test*.catala_*"
           }
-        ]
+        ],
+        "priority": "option"
       }
     ],
     "languages": [


### PR DESCRIPTION
…ion'