### PR TITLE
Add support for scope definition jumping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          opam pin add --dev-repo catala
-          opam install dune
           opam install . --deps-only --with-test
           npm ci
 
@@ -37,4 +35,6 @@ jobs:
           npm run compile
 
       - name: Run tests
-        run: xvfb-run -a npm run test
+        run: |
+          opam exec -- dune runtest
+          xvfb-run -a npm run test

--- a/catala-lsp.opam
+++ b/catala-lsp.opam
@@ -14,18 +14,14 @@ depends: [
   "catala"    { = "dev" }
   "logs"
   "uri"
-  "linol"     { = "dev" }
-  "linol-lwt" { = "dev" }
+  "linol"     { = "0.8" }
+  "linol-lwt" { = "0.8" }
   "qcheck" { with-test & >= "0.21.3" }
   "atdgen" { build }
   "atdgen-runtime"
 ]
 pin-depends: [
   ["catala.dev" "git+https://github.com/CatalaLang/catala"]
-  # TODO: remove linol's pinning once the required changes are
-  # published in opam
-  ["linol.dev" "git+https://github.com/c-cube/linol#a779942f9592a762d26484d03b1f93110dbaf577"]
-  ["linol-lwt.dev" "git+https://github.com/c-cube/linol#a779942f9592a762d26484d03b1f93110dbaf577"]
 ]
 tags: [ "catala" "lsp" ]
 homepage: "https://github.com/CatalaLang/catala-language-server"

--- a/catala-lsp.opam
+++ b/catala-lsp.opam
@@ -4,7 +4,10 @@ name: "catala-lsp"
 maintainer: "Vincent Botbol"
 authors: [ "Vincent Botbol" ]
 license: "Apache-2.0"
-build: ["dune" "build" "-p" name "-j" jobs]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
 depends: [
   "ocaml" {>= "4.14.1"}
   "dune" { >= "3.0" }
@@ -13,6 +16,7 @@ depends: [
   "uri"
   "linol"     { = "dev" }
   "linol-lwt" { = "dev" }
+  "qcheck" { with-test & >= "0.21.3" }
   "atdgen" { build }
   "atdgen-runtime"
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "catala",
-  "version": "0.20.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "catala",
-      "version": "0.20.0",
+      "version": "0.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/react": "^18.3.3",
@@ -1633,10 +1633,11 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/server/src/dune
+++ b/server/src/dune
@@ -1,8 +1,16 @@
 (executable
-  (name         main)
-  (public_name  catala-lsp)
-  (package      catala-lsp)
-  (libraries
+ (name        main)
+ (package     catala-lsp)
+ (public_name catala-lsp)
+ (libraries lib)
+ (modules Main)
+ (flags (:standard) -open Lib)
+)
+
+(library
+ (name      lib)
+ (package   catala-lsp)
+ (libraries
    threads.posix
    lsp
    linol
@@ -15,7 +23,9 @@
    catala.clerk_config
    uri
    re)
-  (flags (:standard)))
+ (modules (:standard \ Main))
+ (flags (:standard))
+)
 
 (alias
  (name lsp)

--- a/server/src/position_map.ml
+++ b/server/src/position_map.ml
@@ -135,10 +135,10 @@ module Make_trie (D : Data) = struct
         match compare_itv itv_p itv with
         | `Equal ->
           if data <> node_r.data then
-            Log.warn (fun m ->
+            Log.debug (fun m ->
                 m
-                  "different data present for new node (%a) vs. previous node \
-                   (%a)"
+                  "Warning: different data present for new node (%a) vs. \
+                   previous node (%a)"
                   pp_node
                   (Node { itv; data; children = [] })
                   pp_node node);

--- a/server/src/position_map.ml
+++ b/server/src/position_map.ml
@@ -201,6 +201,10 @@ module Make (D : Data) = struct
     let j = Pos.get_end_column pos in
     (li, i), (lj, j)
 
+  let pp_raw ppf (p, d) =
+    let open Format in
+    fprintf ppf "@[<h>%a: %a@]" Trie.pp_itv (pos_to_itv p) D.format d
+
   let add pos data variables =
     if pos = Pos.no_pos then variables
     else

--- a/server/src/position_map.ml
+++ b/server/src/position_map.ml
@@ -103,7 +103,7 @@ module Make_trie (D : Data) = struct
         match compare_itv itv n.itv with
         | `Equal -> assert false
         | `Subset -> find_included_nodes (h :: acc) t
-        | `Disjoint_right -> List.rev acc, t
+        | `Disjoint_right -> List.rev (h :: acc), t
         | `Disjoint_left | `Supset | `Right_inclusion _ ->
           (* by construction *) assert false
         | `Left_inclusion (included_itv, disjoint_part) -> (
@@ -126,6 +126,7 @@ module Make_trie (D : Data) = struct
           match sub_trie with
           | [included_node; disjoint_node] ->
             List.rev (included_node :: acc), disjoint_node :: t
+          | [a; b; c] -> List.rev (a :: acc), b :: c :: t
           | _ -> assert false))
     in
     let rec loop acc itv : trie -> trie = function

--- a/server/src/position_map.ml
+++ b/server/src/position_map.ml
@@ -182,7 +182,7 @@ module Make (D : Data) = struct
 
   let pp ppf pmap =
     let open Format in
-    fprintf ppf "@[<v 2>variables:@ @[<v 2>%a@]@]"
+    fprintf ppf "@[<v 2>variables:@ %a@]"
       (FileMap.format ~pp_sep:pp_print_cut Trie.pp_trie)
       pmap
 

--- a/server/src/state.ml
+++ b/server/src/state.ml
@@ -100,7 +100,7 @@ let all_symbols_as_warning file =
         |> List.map snd
         |> List.concat_map
              (fun { Jump.declaration; definitions; usages; types } ->
-               let build r = diag_r Warning (range_of_pos r) "abc" in
+               let build r = diag_r Warning (range_of_pos r) (`String "abc") in
                let declaration = Option.map (fun x -> [x]) declaration in
                [declaration; definitions; usages; types]
                |> List.filter_map (function
@@ -121,7 +121,7 @@ let all_symbols_as_warning file =
                 Format.asprintf "%a : %a" Jump.pp_var v
                   Catala_utils.Pos.format_loc_text r
               in
-              diag_r Warning (range_of_pos r) msg :: acc)
+              diag_r Warning (range_of_pos r) (`String msg) :: acc)
             variables [] );
       ]
 
@@ -144,7 +144,7 @@ let all_diagnostics file =
                       (Printexc.to_string exn));
                 "Cannot display the error description, save the file first."
             in
-            diag_r severity range message)
+            diag_r severity range (`String message))
           (RangeMap.bindings rmap) ))
     errs
 

--- a/server/src/state.ml
+++ b/server/src/state.ml
@@ -436,7 +436,7 @@ let process_document ?previous_file ?contents (uri : string) : t =
             prg.program_ctx.ctx_enums
         in
         let prg = Scopelang.Ast.type_program prg in
-        let jump_table = Jump.populate ctx prg in
+        let jump_table = Jump.populate ctx surface prg in
         !l, Some prg, Some jump_table
     with e ->
       (match e with

--- a/server/test/dune
+++ b/server/test/dune
@@ -1,0 +1,8 @@
+(test
+ (name    test)
+ (package catala-lsp)
+ (libraries lib
+            qcheck)
+ (modules Test)
+ (flags (:standard) -open Lib)
+)

--- a/server/test/test.ml
+++ b/server/test/test.ml
@@ -1,0 +1,96 @@
+(* This file is part of the Catala compiler, a specification language for tax
+   and social benefits computation rules. Copyright (C) 2024 Inria, contributor:
+   Vincent Botbol <vincent.botbol@inria.fr>
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License. *)
+
+open QCheck
+open Catala_utils
+
+module PMap = Position_map.Make (struct
+  include String
+
+  let format = Format.pp_print_string
+end)
+
+let column_gen =
+  let open Gen in
+  let* l = 1 -- 80 in
+  let* r = l -- (l + 50) in
+  return (l, r)
+
+let line_gen =
+  let open Gen in
+  let* l = 1 -- 800 in
+  let* r = l -- (l + 2) in
+  return (l, r)
+
+let pos_gen =
+  let open Gen in
+  let open Pos in
+  let* sl, el = line_gen in
+  let* sc, ec = column_gen in
+  return (from_info "dummy" sl sc el ec)
+
+let data_gen =
+  let open Gen in
+  (* string_size (1 -- 10) ~gen:(oneof [char_range 'a' 'z'; char_range 'A'
+     'Z']) *)
+  string_small_of (oneof [char_range 'a' 'z'; char_range 'A' 'Z'])
+
+let insert_all = List.fold_right (fun (p, v) -> PMap.add p v)
+
+let map_gen =
+  let open Gen in
+  let* l = list_size (10 -- 15) (pair pos_gen data_gen) in
+  return (insert_all l PMap.empty)
+
+let gen_pair = Gen.(pair map_gen (pair pos_gen data_gen))
+
+module S = Set.Make (struct
+  type t = string
+
+  let compare = compare
+end)
+
+let elements t = PMap.fold (fun _ d acc -> S.add d acc) t S.empty
+
+let gen_arb =
+  make
+    ~print:(fun (map, (p, d)) ->
+      let add = PMap.add p d map in
+      Format.asprintf
+        "data: %a@\n\
+         map:@\n\
+         @[<v 2>Before:@ %a@]@\n\
+         @[<v 2>After:@ %a@]@\n\
+         elements diff:@\n\
+         @[<v>%a@]"
+        PMap.pp_raw (p, d) PMap.pp map PMap.pp add
+        Format.(
+          pp_print_list ~pp_sep:pp_print_cut (fun fmt d ->
+              Format.fprintf fmt "data:%s" d))
+        (let l = S.add d (elements map) in
+         let r = elements add in
+         S.diff l r |> S.elements))
+    gen_pair
+
+let test =
+  let insertion_prop (t, (p, d)) =
+    S.equal (S.add d (elements t)) (elements (PMap.add p d t))
+    || Option.is_some (PMap.lookup p t)
+  in
+  QCheck.Test.make ~name:"insertion" ~long_factor:1000 ~count:100_000
+    ~max_fail:0 gen_arb insertion_prop
+
+let () = exit @@ QCheck_runner.run_tests ~long:false [test]


### PR DESCRIPTION
This PR adds support for scope definitions jumping.

It also fixes some miscellaneous bugs and removes linol's dev opam pinning. 
In particular, two bugs were found in the position map data structure. A test was added for it.