### PR TITLE
Prettify scope hovering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,8 @@ FORCE: ;
 clean:
 	rm -f ${TARGET}
 	dune clean
+
+.PHONY: test
+test:
+	dune runtest
+	npm run test

--- a/server/src/jump.ml
+++ b/server/src/jump.ml
@@ -46,6 +46,26 @@ let pp_lookup_entry fmt { declaration; definitions; usages; types } =
     (pp_opt (pp_print_list ~pp_sep:pp_print_cut pp_pos))
     types
 
+let pp_gname
+    (type a b)
+    ~name
+    (module M : Uid.Id with type t = a and type info = b * Pos.t)
+    fmt
+    (v : a) : unit =
+  Format.fprintf fmt "%s: (%s) at %s" (M.to_string v)
+    (M.get_info v |> snd |> Pos.to_string_short)
+    name
+
+let pp_qname
+    (type a)
+    ~name
+    (module M : Uid.Qualified with type t = a)
+    fmt
+    (v : a) : unit =
+  Format.fprintf fmt "%s (%s) at %s" (M.to_string v)
+    (M.get_info v |> snd |> Pos.to_string_short)
+    name
+
 let empty_lookup =
   { declaration = None; definitions = None; usages = None; types = None }
 

--- a/server/src/jump.ml
+++ b/server/src/jump.ml
@@ -71,6 +71,13 @@ let empty_lookup =
 
 type jump = { hash : int; name : string; typ : typ }
 
+type sjump = {
+  hash : int;
+  name : string;
+  scope_decl_name : ScopeName.t;
+  scope_sig : scope_var_ty ScopeVar.Map.t;
+}
+
 type mjump = {
   hash : int;
   name : string;
@@ -85,6 +92,8 @@ type var =
   | Usage of jump
   | Type of jump
   | Literal of typ
+  | Scope_decl of sjump
+  | Scope_def of sjump
   | Module_def of mjump
   | Module_use of mjump
   | Module_decl of mjump
@@ -97,19 +106,10 @@ let pp_module_jump fmt { interface; alias; hash; _ } =
     (pp_opt (fun fmt alias -> fprintf fmt "(alias:%s)" alias))
     alias
 
-let make_mjump
-    (mname : ModuleName.t)
-    (interface : Surface.Ast.interface)
-    ?alias
-    k =
-  let mjump : mjump =
-    let hash = Hashtbl.hash (Mark.get interface.intf_modname.module_name) in
-    { hash; name = ModuleName.to_string mname; alias; interface }
-  in
-  match k with
-  | `Def -> Module_def mjump
-  | `Use -> Module_use mjump
-  | `Decl -> Module_decl mjump
+let make_mjump ?alias (mname : ModuleName.t) (interface : Surface.Ast.interface)
+    =
+  let hash = Hashtbl.hash (Mark.get interface.intf_modname.module_name) in
+  { hash; name = ModuleName.to_string mname; alias; interface }
 
 let pp_var ppf =
   let open Format in
@@ -120,6 +120,8 @@ let pp_var ppf =
   | Usage { name; hash; _ } -> fprintf ppf "usage: %s#%d" name hash
   | Type { name; hash; _ } -> fprintf ppf "type: %s#%d" name hash
   | Literal typ -> fprintf ppf "literal: %a" Print.typ_debug typ
+  | Scope_decl { name; hash; _ } -> fprintf ppf "scope_decl: %s#%d" name hash
+  | Scope_def { name; hash; _ } -> fprintf ppf "scope_def: %s#%d" name hash
   | Module_use mjump -> fprintf ppf "mod_usage: %a" pp_module_jump mjump
   | Module_decl mjump -> fprintf ppf "mod_decl: %a" pp_module_jump mjump
   | Module_def mjump -> fprintf ppf "mod_def: %a" pp_module_jump mjump
@@ -159,7 +161,7 @@ let find key proj bindings =
 
 let populate_struct_def
     (ctx : Desugared.Name_resolution.context)
-    (module_lookup : ModuleName.t -> Surface.Ast.interface * string option)
+    (module_lookup : ModuleName.t -> mjump)
     name
     fields
     m
@@ -168,10 +170,9 @@ let populate_struct_def
     (* Populate struct's path components *)
     List.fold_left
       (fun acc mname ->
-        let interface, alias = module_lookup mname in
-        let mjump = make_mjump mname interface ?alias `Use in
+        let mjump = module_lookup mname in
         let pos = Mark.get (ModuleName.get_info mname) in
-        PMap.add pos mjump acc)
+        PMap.add pos (Module_use mjump) acc)
       m (StructName.path name)
   in
   match
@@ -193,7 +194,7 @@ let populate_struct_def
         Mark.add pos_decl (TStruct struct_decl)
       in
       let jump = { hash; name; typ } in
-      PMap.(add struct_pos (Usage jump) m |> add struct_pos (Type jump))
+      PMap.add_all struct_pos [Usage jump; Type jump] m
     in
     (* Add a reference for all fields *)
     StructField.Map.fold
@@ -217,7 +218,7 @@ let populate_struct_def
 
 let populate_enum_inject
     (ctx : Desugared.Name_resolution.context)
-    (module_lookup : ModuleName.t -> Surface.Ast.interface * string option)
+    (module_lookup : ModuleName.t -> mjump)
     (enum_name : EnumName.t)
     (cons : EnumConstructor.t)
     m =
@@ -225,10 +226,9 @@ let populate_enum_inject
     (* Populate enum's path components *)
     List.fold_left
       (fun acc mname ->
-        let interface, alias = module_lookup mname in
-        let mjump = make_mjump mname interface ?alias `Use in
+        let mjump = module_lookup mname in
         let pos = Mark.get (ModuleName.get_info mname) in
-        PMap.add pos mjump acc)
+        PMap.add pos (Module_use mjump) acc)
       m (EnumName.path enum_name)
   in
   let enum_decl_opt =
@@ -261,25 +261,26 @@ let populate_enum_inject
       let pos = Mark.get (EnumConstructor.get_info cons) in
       PMap.add pos var m)
 
-let populate_scopecall ctx module_lookup pos scope args acc f =
-  let ((name, decl_pos) as scope_info) = ScopeName.get_info scope in
+let populate_scopecall
+    (ctx : Desugared.Name_resolution.context)
+    module_lookup
+    scope_lookup
+    pos
+    scope
+    args
+    acc
+    f =
   let acc =
     (* Populate scope's path components *)
     List.fold_left
       (fun acc mname ->
-        let interface, alias = module_lookup mname in
-        let mjump = make_mjump mname interface ?alias `Use in
+        let mjump = module_lookup mname in
         let pos = Mark.get (ModuleName.get_info mname) in
-        PMap.add pos mjump acc)
+        PMap.add pos (Module_use mjump) acc)
       acc (ScopeName.path scope)
   in
-  let typ : typ =
-    let scope_ctx = Desugared.Name_resolution.get_scope_context ctx scope in
-    TStruct scope_ctx.scope_out_struct, decl_pos
-  in
-  let hash = Hashtbl.hash scope_info in
-  let var = Usage { name; hash; typ } in
-  let acc = PMap.add pos var acc in
+  let sjump = ScopeName.Map.find scope scope_lookup in
+  let acc = PMap.add pos (Scope_def sjump) acc in
   ScopeVar.Map.fold
     (fun scope_var (def_pos, e) acc ->
       let name = ScopeVar.to_string scope_var in
@@ -299,7 +300,8 @@ let populate_scopecall ctx module_lookup pos scope args acc f =
 
 let traverse_expr
     (ctx : Desugared.Name_resolution.context)
-    (module_lookup : ModuleName.t -> Surface.Ast.interface * string option)
+    (module_lookup : ModuleName.t -> mjump)
+    (scope_lookup : sjump ScopeName.Map.t)
     (e : (scopelang, typed) gexpr)
     m =
   let open Shared_ast in
@@ -376,7 +378,8 @@ let traverse_expr
           PMap.add pos var acc |> f bnd_ctx e)
         cases acc
     | EScopeCall { scope; args } ->
-      populate_scopecall ctx module_lookup pos scope args acc (f bnd_ctx)
+      populate_scopecall ctx module_lookup scope_lookup pos scope args acc
+        (f bnd_ctx)
     | EEmpty | EIfThenElse _ | EArray _ | EAppOp _ | EApp _ | ETuple _
     | ETupleAccess _ | EFatalError _ | EPureDefault _ | EErrorOnEmpty _ ->
       Expr.shallow_fold (f bnd_ctx) e acc
@@ -385,7 +388,7 @@ let traverse_expr
 
 let rec traverse_typ
     (ctx : Desugared.Name_resolution.context)
-    (module_lookup : ModuleName.t -> Surface.Ast.interface * string option)
+    (module_lookup : ModuleName.t -> mjump)
     ((typ, pos) : naked_typ * Pos.t)
     m : PMap.pmap =
   match typ with
@@ -394,10 +397,9 @@ let rec traverse_typ
       (* Populate struct's path components *)
       List.fold_left
         (fun acc mname ->
-          let interface, alias = module_lookup mname in
-          let mjump = make_mjump mname interface ?alias `Use in
+          let mjump = module_lookup mname in
           let pos = Mark.get (ModuleName.get_info mname) in
-          PMap.add pos mjump acc)
+          PMap.add pos (Module_use mjump) acc)
         m
         (StructName.path struct_name)
     in
@@ -411,10 +413,9 @@ let rec traverse_typ
       (* Populate enum's path components *)
       List.fold_left
         (fun acc mname ->
-          let interface, alias = module_lookup mname in
-          let mjump = make_mjump mname interface ?alias `Use in
+          let mjump = module_lookup mname in
           let pos = Mark.get (ModuleName.get_info mname) in
-          PMap.add pos mjump acc)
+          PMap.add pos (Module_use mjump) acc)
         m (EnumName.path enum_name)
     in
     let name = EnumName.to_string enum_name in
@@ -432,7 +433,8 @@ let rec traverse_typ
 
 let traverse_scope_def
     ctx
-    (module_lookup : ModuleName.t -> Surface.Ast.interface * string option)
+    (module_lookup : ModuleName.t -> mjump)
+    scope_lookup
     (rule : typed rule)
     m : PMap.pmap =
   match rule with
@@ -444,10 +446,10 @@ let traverse_scope_def
     let var = Definition { name; hash; typ } in
     let m = List.fold_right (fun p -> PMap.add p var) pos_l m in
     let m = traverse_typ ctx module_lookup typ m in
-    traverse_expr ctx module_lookup e m
-  | Assertion e -> traverse_expr ctx module_lookup e m
+    traverse_expr ctx module_lookup scope_lookup e m
+  | Assertion e -> traverse_expr ctx module_lookup scope_lookup e m
 
-let traverse_scope_sig ctx module_lookup scope m : PMap.pmap =
+let traverse_scope_sig ctx module_lookup (scope : _ scope_decl) m : PMap.pmap =
   ScopeVar.Map.fold
     (fun scope_var var_ty m ->
       (* FIXME: subscope type definition is buggy *)
@@ -461,17 +463,19 @@ let traverse_scope_sig ctx module_lookup scope m : PMap.pmap =
 
 let traverse_scope
     ctx
-    (module_lookup : ModuleName.t -> Surface.Ast.interface * string option)
+    (module_lookup : ModuleName.t -> mjump)
+    scope_lookup
     (scope : typed scope_decl)
     m : PMap.pmap =
   let m = traverse_scope_sig ctx module_lookup scope m in
   List.fold_right
-    (traverse_scope_def ctx module_lookup)
+    (traverse_scope_def ctx module_lookup scope_lookup)
     scope.scope_decl_rules m
 
 let traverse_topdef
     ctx
-    (module_lookup : ModuleName.t -> Surface.Ast.interface * string option)
+    (module_lookup : ModuleName.t -> mjump)
+    scope_lookup
     (topdef : TopdefName.t)
     ((e, typ, _vis) : typed expr * typ * visibility)
     m : PMap.pmap =
@@ -480,11 +484,11 @@ let traverse_topdef
   let hash = Hashtbl.hash (TopdefName.get_info topdef) in
   let topdef = Topdef { name; hash; typ } in
   let m = PMap.add topdef_pos topdef m in
-  traverse_expr ctx module_lookup e m
+  traverse_expr ctx module_lookup scope_lookup e m
 
 let traverse_ctx
     (ctx : Desugared.Name_resolution.context)
-    (module_lookup : ModuleName.t -> Surface.Ast.interface * string option)
+    (module_lookup : ModuleName.t -> mjump)
     m : PMap.pmap =
   let m =
     StructName.Map.fold
@@ -531,32 +535,53 @@ let traverse_ctx
 
 let traverse
     (ctx : Desugared.Name_resolution.context)
-    (module_lookup : ModuleName.t -> Surface.Ast.interface * string option)
-    (prog : typed program)
-    (variables : PMap.pmap) =
-  let m =
-    ModuleName.Map.fold
-      (fun _m_name decl_map acc ->
-        ScopeName.Map.fold
-          (fun _sname scope acc ->
-            traverse_scope_sig ctx module_lookup (Mark.remove scope) acc)
-          decl_map acc)
-      prog.program_modules variables
-  in
-  let m =
-    TopdefName.Map.fold
-      (traverse_topdef ctx module_lookup)
-      prog.program_topdefs m
-  in
+    (module_lookup : ModuleName.t -> mjump)
+    (prog : _ program)
+    (m : PMap.pmap) =
   let all_scopes =
     ScopeName.Map.values prog.program_scopes |> List.map Mark.remove
   in
-  let m = List.fold_right (traverse_scope ctx module_lookup) all_scopes m in
-  traverse_ctx ctx module_lookup m
+  let add_scope_sjump (m, scope_lookup_map) (scope : _ scope_decl) =
+    let scope_decl_name = scope.scope_decl_name in
+    let ((name, pos) as info) = ScopeName.get_info scope_decl_name in
+    let hash = Hashtbl.hash info in
+    let sjump = { name; hash; scope_decl_name; scope_sig = scope.scope_sig } in
+    let m = PMap.add pos (Scope_decl sjump) m in
+    let scope_lookup_map =
+      ScopeName.Map.add scope_decl_name sjump scope_lookup_map
+    in
+    m, scope_lookup_map
+  in
+  let m, scope_lookup =
+    ModuleName.Map.fold
+      (fun _m_name decl_map (acc, scope_lookup_map) ->
+        ScopeName.Map.fold
+          (fun _sname scope (acc, scope_lookup_map) ->
+            let scope = Mark.remove scope in
+            let acc = traverse_scope_sig ctx module_lookup scope acc in
+            add_scope_sjump (acc, scope_lookup_map) scope)
+          decl_map (acc, scope_lookup_map))
+      prog.program_modules (m, ScopeName.Map.empty)
+  in
+  let m, (scope_lookup : sjump ScopeName.Map.t) =
+    List.fold_left add_scope_sjump (m, scope_lookup) all_scopes
+  in
+  let m =
+    TopdefName.Map.fold
+      (traverse_topdef ctx module_lookup scope_lookup)
+      prog.program_topdefs m
+  in
+  let m =
+    List.fold_left
+      (fun m scope -> traverse_scope ctx module_lookup scope_lookup scope m)
+      m all_scopes
+  in
+  traverse_ctx ctx module_lookup m, scope_lookup
 
 let add_scope_definitions
     (ctx : Desugared.Name_resolution.context)
     (surface : Surface.Ast.program)
+    (scope_lookup_map : sjump ScopeName.Map.t)
     (variables : PMap.t) =
   let rec process vars_acc = function
     | Surface.Ast.CodeBlock (cb, _, _) ->
@@ -568,19 +593,11 @@ let add_scope_definitions
               Mark.get s_use.scope_use_name
               |> fun p -> Pos.overwrite_law_info p []
             in
-            let name = Mark.remove s_use.scope_use_name in
             let scope_uid =
               Desugared.Name_resolution.get_scope ctx s_use.scope_use_name
             in
-            let typ : typ =
-              let ty_pos = ScopeName.get_info scope_uid |> Mark.get in
-              let scope_ctx =
-                Desugared.Name_resolution.get_scope_context ctx scope_uid
-              in
-              TStruct scope_ctx.scope_out_struct, ty_pos
-            in
-            let hash = Hashtbl.hash (ScopeName.get_info scope_uid) in
-            let var = Definition { name; hash; typ } in
+            let sjump = ScopeName.Map.find scope_uid scope_lookup_map in
+            let var = Scope_def sjump in
             PMap.add pos var vars
           | ScopeDecl _ | StructDecl _ | EnumDecl _ | Topdef _ -> vars)
         vars_acc cb
@@ -594,8 +611,7 @@ let populate_modules
     (modules_itf : Surface.Ast.interface ModuleName.Map.t)
     (prog : typed program)
     (surface : Surface.Ast.program)
-    (acc : PMap.t) :
-    PMap.t * (ModuleName.t -> Surface.Ast.interface * string option) =
+    (acc : PMap.t) : PMap.t * (ModuleName.t -> mjump) =
   let module C = Map.Make (String) in
   let convert_map =
     ModuleName.Map.fold
@@ -611,13 +627,13 @@ let populate_modules
       let mname_pos = Mark.get (ModuleName.get_info mname) in
       let interface = ModuleName.Map.find mname modules_itf in
       let alias = if alias <> name then Some alias else None in
-      let decl_mjump = make_mjump mname interface ?alias `Decl in
-      let def_mjump = make_mjump mname interface ?alias `Def in
+      let mjump = make_mjump mname interface ?alias in
       let acc =
-        if Option.is_some alias then PMap.add palias decl_mjump acc else acc
+        if Option.is_some alias then PMap.add palias (Module_decl mjump) acc
+        else acc
       in
-      let acc = PMap.add pname decl_mjump acc in
-      PMap.add mname_pos def_mjump acc
+      let acc = PMap.add pname (Module_decl mjump) acc in
+      PMap.add mname_pos (Module_def mjump) acc
     with exn ->
       Log.warn (fun m ->
           m "exception %s while processing module use" (Printexc.to_string exn));
@@ -640,7 +656,9 @@ let populate_modules
           itf, alias)
         modules_itf
     in
-    fun mname -> ModuleName.Map.find mname itf_map
+    fun mname ->
+      let interface, alias = ModuleName.Map.find mname itf_map in
+      make_mjump mname interface ?alias
   in
   let acc =
     match surface.program_module with
@@ -650,8 +668,8 @@ let populate_modules
         let interface = Surface.Parser_driver.load_interface input_src in
         let pos = Mark.get module_name in
         let mname = ModuleName.fresh module_name in
-        let def_mjump = make_mjump mname interface `Def in
-        PMap.add pos def_mjump acc
+        let mjump = make_mjump mname interface in
+        PMap.add pos (Module_def mjump) acc
       with exn ->
         (* Ignore errors, the current file might be *)
         Log.warn (fun m ->
@@ -670,8 +688,10 @@ let populate
   let variables, mod_lookup =
     populate_modules input_src modules_itf prog surface PMap.empty
   in
-  let variables = traverse ctx mod_lookup prog variables in
-  let variables = add_scope_definitions ctx surface variables in
+  let variables, scope_lookup_map = traverse ctx mod_lookup prog variables in
+  let variables =
+    add_scope_definitions ctx surface scope_lookup_map variables
+  in
   let add f = function None -> Some (f empty_lookup) | Some v -> Some (f v) in
   let add_def p =
     add (fun v ->
@@ -713,6 +733,8 @@ let populate
               | Declaration jump -> Some (add_decl p, jump.hash)
               | Usage jump -> Some (add_usage p, jump.hash)
               | Type jump -> Some (add_type p, jump.hash)
+              | Scope_def { hash; _ } -> Some (add_decl p, hash)
+              | Scope_decl { hash; _ } -> Some (add_decl p, hash)
               | Module_use { hash; _ } -> Some (add_usage p, hash)
               | Module_decl { hash; _ } -> Some (add_decl p, hash)
               | Module_def { hash; _ } -> Some (add_def p, hash)
@@ -730,8 +752,11 @@ let lookup (tables : t) (p : Pos.t) : lookup_entry list =
   let proj = function
     | Topdef j | Definition j | Declaration j | Usage j | Type j ->
       LTable.find_opt j.hash tables.lookup_table
-    | Module_use { hash; _ } | Module_decl { hash; _ } | Module_def { hash; _ }
-      ->
+    | Scope_def { hash; _ }
+    | Scope_decl { hash; _ }
+    | Module_use { hash; _ }
+    | Module_decl { hash; _ }
+    | Module_def { hash; _ } ->
       LTable.find_opt hash tables.lookup_table
     | Literal _ -> None
   in
@@ -741,19 +766,24 @@ let lookup (tables : t) (p : Pos.t) : lookup_entry list =
 type type_lookup =
   | Expr of typ
   | Type of typ
+  | Scope of (ScopeName.t * Scopelang.Ast.scope_var_ty ScopeVar.Map.t)
   | Module of (Surface.Ast.interface * string option)
 
 module Ord_lookup = Set.Make (struct
   type t = type_lookup
 
-  let rec compare l r =
+  let compare l r =
     match l, r with
     | Module _, Module _ -> 0
     | Module _, _ -> 1
+    | _, Module _ -> -1
+    | Scope _, Scope _ -> 0
+    | Scope _, _ -> 1
+    | _, Scope _ -> -1
     | Type _, Type _ -> 0
     | Type _, _ -> 1
+    | _, Type _ -> -1
     | Expr _, Expr _ -> 0
-    | l, r -> -1 * compare r l
 end)
 
 let lookup_type (tables : t) (p : Pos.t) :
@@ -762,6 +792,9 @@ let lookup_type (tables : t) (p : Pos.t) :
     | Topdef j | Definition j | Declaration j | Usage j -> Expr j.typ
     | Type j -> Type j.typ
     | Literal typ -> Expr typ
+    | Scope_def { scope_decl_name; scope_sig; _ }
+    | Scope_decl { scope_decl_name; scope_sig; _ } ->
+      Scope (scope_decl_name, scope_sig)
     | Module_use { interface; alias; _ }
     | Module_decl { interface; alias; _ }
     | Module_def { interface; alias; _ } ->
@@ -786,6 +819,8 @@ let var_to_symbol (p : Pos.t) (var : var) : Linol_lwt.SymbolInformation.t option
     | Definition v -> Some (v.name, Function)
     | Declaration v -> Some (v.name, Interface)
     | Usage v -> Some (v.name, Variable)
+    | Scope_def v -> Some (v.name, Function)
+    | Scope_decl v -> Some (v.name, Interface)
     | Module_use v | Module_decl v | Module_def v -> Some (v.name, Module)
     | Type _ | Literal _ -> None
   in

--- a/server/src/position_map.ml
+++ b/server/src/position_map.ml
@@ -199,16 +199,18 @@ module Make (D : Data) = struct
     let open Format in
     fprintf ppf "@[<h>%a: %a@]" Trie.pp_itv (pos_to_itv p) D.format d
 
-  let add pos data variables =
+  let add_all pos data variables =
     if pos = Pos.no_pos then variables
     else
       let itv = pos_to_itv pos in
-      let data = Trie.DS.singleton data in
+      let data = DS.of_list data in
       FileMap.update (Pos.get_file pos)
         (function
           | None -> Some [Trie.Node { itv; data; children = [] }]
           | Some trie -> Some (Trie.insert_all itv data trie))
         variables
+
+  let add pos data variables = add_all pos [data] variables
 
   let lookup pos pmap =
     let ( let* ) = Option.bind in

--- a/server/src/server.ml
+++ b/server/src/server.ml
@@ -375,7 +375,7 @@ class catala_lsp_server =
         ()
         : Locations.t option Lwt.t =
       let f = self#use_or_process_file (DocumentUri.to_path uri) in
-      match State.lookup_type_definition f pos with
+      match State.lookup_type_declaration f pos with
       | None -> Lwt.return_none
       | Some (file, range) ->
         let uri = DocumentUri.of_path file in

--- a/server/src/state.ml
+++ b/server/src/state.ml
@@ -210,7 +210,9 @@ let lookup_type_declaration f p =
     Some (of_position pos)
   | Module ({ Surface.Ast.intf_modname = itf; _ }, _) ->
     Some (of_position @@ Mark.get itf.module_name)
-  | _ -> None
+  | Scope (scope_decl_name, _) ->
+    Some (of_position @@ Mark.get (ScopeName.get_info scope_decl_name))
+  | Expr _ | Type _ -> None
 
 let lookup_document_symbols file =
   let variables =


### PR DESCRIPTION
This PR adds pretty markdown on scope hovering instead of displaying a weird <struct> message.

Before:
![image](https://github.com/user-attachments/assets/40a489a8-0c8b-45fb-8af0-08dcd41f33e9)

After:
![image](https://github.com/user-attachments/assets/00b9232a-318c-4d61-9d03-65d20fcb360a)

And, as per usual, a bunch of misc. refactoring and fixes comes along.