### PR TITLE
Input and UI improvements

### DIFF
--- a/src/TestFileEditor.tsx
+++ b/src/TestFileEditor.tsx
@@ -355,8 +355,14 @@ export default function TestFileEditor({
 
 function parseResultsToUiState(tests: ParseResults): UIState {
   switch (tests.kind) {
-    case 'Error':
+    case 'ParseError':
       return { state: 'error', message: tests.value };
+    case 'EmptyTestListMismatch':
+      //XXX make into its own UI section
+      return {
+        state: 'error',
+        message: 'Found empty test list but nonempty buffer',
+      };
     case 'Results':
       return { state: 'success', tests: tests.value };
     default:

--- a/src/generated/test_case.ts
+++ b/src/generated/test_case.ts
@@ -103,7 +103,8 @@ export type TestList = Test[]
 export type ScopeDefList = ScopeDef[]
 
 export type ParseResults =
-| { kind: 'Error'; value: string }
+| { kind: 'ParseError'; value: string }
+| { kind: 'EmptyTestListMismatch' }
 | { kind: 'Results'; value: TestList }
 
 export type TestRunResults =
@@ -440,23 +441,36 @@ export function readScopeDefList(x: any, context: any = x): ScopeDefList {
 
 export function writeParseResults(x: ParseResults, context: any = x): any {
   switch (x.kind) {
-    case 'Error':
-      return ['Error', _atd_write_string(x.value, x)]
+    case 'ParseError':
+      return ['ParseError', _atd_write_string(x.value, x)]
+    case 'EmptyTestListMismatch':
+      return 'EmptyTestListMismatch'
     case 'Results':
       return ['Results', writeTestList(x.value, x)]
   }
 }
 
 export function readParseResults(x: any, context: any = x): ParseResults {
-  _atd_check_json_tuple(2, x, context)
-  switch (x[0]) {
-    case 'Error':
-      return { kind: 'Error', value: _atd_read_string(x[1], x) }
-    case 'Results':
-      return { kind: 'Results', value: readTestList(x[1], x) }
-    default:
-      _atd_bad_json('ParseResults', x, context)
-      throw new Error('impossible')
+  if (typeof x === 'string') {
+    switch (x) {
+      case 'EmptyTestListMismatch':
+        return { kind: 'EmptyTestListMismatch' }
+      default:
+        _atd_bad_json('ParseResults', x, context)
+        throw new Error('impossible')
+    }
+  }
+  else {
+    _atd_check_json_tuple(2, x, context)
+    switch (x[0]) {
+      case 'ParseError':
+        return { kind: 'ParseError', value: _atd_read_string(x[1], x) }
+      case 'Results':
+        return { kind: 'Results', value: readTestList(x[1], x) }
+      default:
+        _atd_bad_json('ParseResults', x, context)
+        throw new Error('impossible')
+    }
   }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -575,3 +575,104 @@
     transform: translateY(0);
   }
 }
+
+/* File and scope selection wizard styling */
+.file-select-button {
+  background-color: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+  border: none;
+  padding: 8px 16px;
+  border-radius: 2px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  margin: 12px 0;
+  width: 100%;
+  justify-content: center;
+}
+
+.file-select-button:hover {
+  background-color: var(--vscode-button-hoverBackground);
+}
+
+.file-select-button .codicon {
+  font-size: 16px;
+}
+
+.modal-content p {
+  margin-bottom: 12px;
+  color: var(--vscode-foreground);
+}
+
+.modal-content select {
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 20px;
+  border: 1px solid var(--vscode-input-border);
+  background-color: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  font-size: 13px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.modal-content select:focus {
+  outline: none;
+  border-color: var(--vscode-focusBorder);
+  box-shadow: 0 0 0 2px var(--vscode-focusBorder);
+}
+
+.modal-content select option {
+  padding: 8px;
+}
+
+.modal-content .selected-file {
+  background-color: var(--vscode-editor-inactiveSelectionBackground);
+  border-radius: 3px;
+  padding: 6px 10px;
+  margin-bottom: 16px;
+  font-family: var(--vscode-editor-font-family);
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  position: relative;
+  word-break: break-all;
+}
+
+.modal-content .selected-file .codicon-file {
+  margin-right: 6px;
+  color: var(--vscode-symbolIcon-fileForeground);
+}
+
+.modal-step-indicator {
+  display: flex;
+  margin-bottom: 20px;
+  gap: 2px;
+}
+
+.modal-step {
+  flex: 1;
+  height: 4px;
+  background-color: var(--vscode-button-secondaryBackground);
+  opacity: 0.5;
+  border-radius: 2px;
+}
+
+.modal-step.active {
+  background-color: var(--vscode-button-background);
+  opacity: 1;
+}
+
+.modal-title-with-step {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.modal-step-count {
+  color: var(--vscode-descriptionForeground);
+  font-size: 12px;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -536,3 +536,42 @@
 .array-add:hover {
   background-color: var(--vscode-button-hoverBackground);
 }
+
+.test-editor-warning {
+  background-color: var(--vscode-inputValidation-warningBackground);
+  border: 1px solid var(--vscode-inputValidation-warningBorder);
+  border-radius: 4px;
+  padding: 15px;
+  margin: 20px 0;
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+.test-editor-warning h2 {
+  color: var(--vscode-inputValidation-warningForeground);
+  margin-top: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.test-editor-warning p {
+  margin: 10px 0;
+  line-height: 1.5;
+  color: var(--vscode-foreground);
+}
+
+.test-editor-warning-actions {
+  display: flex;
+  justify-content: flex-start;
+  margin-top: 15px;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/testCaseCompilerInterop.ts
+++ b/src/testCaseCompilerInterop.ts
@@ -31,13 +31,19 @@ export function parseTestFile(
       ['testcase', 'read', '-l', lang, '--buffer-path', bufferPath, '-'],
       { input: content, ...(cwd && { cwd }) }
     );
+    const testList = readTestList(JSON.parse(results.toString()));
+    if (content.trim() !== '' && testList.length == 0) {
+      return {
+        kind: 'EmptyTestListMismatch',
+      };
+    }
     return {
       kind: 'Results',
-      value: readTestList(JSON.parse(results.toString())),
+      value: testList,
     };
   } catch (error) {
     return {
-      kind: 'Error',
+      kind: 'ParseError',
       value: String((error as SpawnSyncReturns<string | Buffer>).stderr),
     };
   }

--- a/test-case-parser/test_case.atd
+++ b/test-case-parser/test_case.atd
@@ -96,8 +96,9 @@ type scope_def_list = scope_def list
 (* Message exchange within extension (shell <-> webview) *)
 
 type parse_results = [
-  | Error of string
-  | Results of test_list
+  | ParseError of string (* compiler signals a parsing error *)
+  | EmptyTestListMismatch (* buffer is non-empty, but empty test list returned *)
+  | Results of test_list (* may be empty, that's fine as long as the buffer is empty too *)
 ]
 
 type test_run_results = [


### PR DESCRIPTION
This PR proposes a few usability improvements

- prevents opening the "welcome" dialog when a file is nonempty, and parsing is not in error (i.e. the catala file is valid) but no tests are returned by the parser (because the contents of the file does not conform to our expectation for test cases).

Instead it will show a warning

![image](https://github.com/user-attachments/assets/6995eedc-35a6-4306-a37e-d20dbc54dbbd)

- improves styling for the 'new test' wizard
