### PR TITLE
Remove clerk run hack

### DIFF
--- a/src/testCaseCompilerInterop.ts
+++ b/src/testCaseCompilerInterop.ts
@@ -10,7 +10,6 @@ import {
   type TestRunResults,
 } from './generated/test_case';
 import { logger } from './logger';
-import path = require('path');
 import { Uri, window, workspace } from 'vscode';
 
 function getCwd(bufferPath: string): string | undefined {
@@ -81,9 +80,6 @@ export function runTestScope(
    */
 
   const cmd = 'catala';
-  filename = path.isAbsolute(filename)
-    ? path.relative(process.cwd(), filename)
-    : filename;
 
   const args = ['testcase', 'run', '--scope', testScope, filename];
   logger.log(`Exec: ${cmd} ${args.join(' ')}`);

--- a/src/testCaseCompilerInterop.ts
+++ b/src/testCaseCompilerInterop.ts
@@ -88,17 +88,6 @@ export function runTestScope(
   const args = ['testcase', 'run', '--scope', testScope, filename];
   logger.log(`Exec: ${cmd} ${args.join(' ')}`);
   try {
-    // HACK: use 'clerk run' as a preamble (does not output test result,
-    // but builds any dependencies as a side-effect which we need currently
-    // for the run plugin!)
-    execFileSync('clerk', [
-      'run',
-      filename,
-      '-s',
-      testScope,
-      '-I',
-      './test-case-parser/examples',
-    ]);
     const result = execFileSync(cmd, args);
     const test = readTest(JSON.parse(result.toString()));
     return {


### PR DESCRIPTION
Fixes the remaining paths that were hard-coded for the initial CNAF demo.