### PR TITLE
Rprimet@input improvements

### DIFF
--- a/src/AssertionValueEditor.tsx
+++ b/src/AssertionValueEditor.tsx
@@ -5,17 +5,23 @@ type Props = {
   testIO: TestIo;
   onValueChange: (newValue: TestIo) => void;
   onAssertionDeletion: () => void;
+  validationId?: string;
 };
 
 export default function AssertionValueEditor({
   testIO,
   onValueChange,
   onAssertionDeletion,
+  validationId,
 }: Props): React.ReactElement {
   return (
     <div className="assertion-value-editor">
       <div className="assertion-value-content">
-        <ValueEditor testIO={testIO} onValueChange={onValueChange} />
+        <ValueEditor
+          testIO={testIO}
+          onValueChange={onValueChange}
+          validationId={validationId}
+        />
       </div>
       <button
         className="assertion-delete"

--- a/src/TestFileEditor.tsx
+++ b/src/TestFileEditor.tsx
@@ -153,7 +153,7 @@ export default function TestFileEditor({
 
         vscode.postMessage(
           writeUpMessage({
-            kind: 'Edit',
+            kind: 'GuiEdit',
             value: newTestState,
           })
         );
@@ -173,7 +173,7 @@ export default function TestFileEditor({
 
         vscode.postMessage(
           writeUpMessage({
-            kind: 'Edit',
+            kind: 'GuiEdit',
             value: newTestState,
           })
         );

--- a/src/TestInputsEditor.tsx
+++ b/src/TestInputsEditor.tsx
@@ -1,6 +1,7 @@
-import type { ReactElement } from 'react';
+import { type ReactElement, useEffect } from 'react';
 import type { TestInputs, TestIo } from './generated/test_case';
 import ValueEditor from './ValueEditors';
+import { clearValidationErrors } from './validation';
 
 type Props = {
   test_inputs: TestInputs;
@@ -12,6 +13,15 @@ type Props = {
 //
 // This component aggregates all inputs for a single test.
 export default function TestInputsEditor(props: Props): ReactElement {
+  // Clear validation errors when component unmounts
+  useEffect(() => {
+    return (): void => {
+      // Clean up validation errors for this component
+      Array.from(props.test_inputs.keys()).forEach((inputName) => {
+        clearValidationErrors(`input_${inputName}`);
+      });
+    };
+  }, []);
   // TODO: discuss behavior w.r.t mandatory and optional inputs
   // and implement an UI that reflects those (e.g. reset an optional
   // input to its default value and mark it as unedited, provide user
@@ -37,6 +47,7 @@ export default function TestInputsEditor(props: Props): ReactElement {
                   <ValueEditor
                     testIO={testIo}
                     onValueChange={onTestInputChange}
+                    validationId={`input_${inputName}`}
                   />
                 </td>
               </tr>

--- a/src/TestOutputsEditor.tsx
+++ b/src/TestOutputsEditor.tsx
@@ -1,7 +1,8 @@
 import type { Test, TestIo } from './generated/test_case';
 import AssertionValueEditor from './AssertionValueEditor';
 import { getDefaultValue } from './defaults';
-import type { ReactElement } from 'react';
+import { type ReactElement, useEffect } from 'react';
+import { clearValidationErrors } from './validation';
 
 type Props = {
   test: Test;
@@ -33,6 +34,16 @@ export default function TestOutputsEditor({
   onTestChange: onTestAssertsChange,
 }: Props): ReactElement {
   const { test_outputs, tested_scope } = test;
+
+  // Clear validation errors when component unmounts
+  useEffect(() => {
+    return (): void => {
+      // Clean up validation errors for this component
+      Array.from(test_outputs.keys()).forEach((outputName) => {
+        clearValidationErrors(`output_${outputName}`);
+      });
+    };
+  }, [test_outputs]);
 
   function onAssertAdd(outputName: string): void {
     const outputType = tested_scope.outputs.get(outputName);
@@ -83,6 +94,7 @@ export default function TestOutputsEditor({
                         onAssertValueChange(outputName, newValue)
                       }
                       onAssertionDeletion={() => onAssertDelete(outputName)}
+                      validationId={`output_${outputName}`}
                     />
                   ) : (
                     <button

--- a/src/ValueEditors.tsx
+++ b/src/ValueEditors.tsx
@@ -401,16 +401,7 @@ type BoolEditorProps = {
 };
 
 function BoolEditor(props: BoolEditorProps): ReactElement {
-  // Boolean selects don't typically need validation as they're constrained
-  // But we'll clear any validation errors when the component unmounts
-  useEffect(() => {
-    return () => {
-      if (props.validationId) {
-        clearValidationErrors(props.validationId);
-      }
-    };
-  }, [props.validationId]);
-
+  // Boolean selects don't need validation as they're constrained by the select options
   return (
     <div className="value-editor">
       <select
@@ -433,14 +424,7 @@ type DurationEditorProps = {
 };
 
 function DurationEditor(props: DurationEditorProps): ReactElement {
-  // Clean up validation on unmount
-  useEffect(() => {
-    return (): void => {
-      if (props.validationId) {
-        clearValidationErrors(props.validationId);
-      }
-    };
-  }, [props.validationId]);
+  // Duration editor uses number inputs which have built-in validation
   const [years, setYears] = useState(props.value?.years ?? 0);
   const [months, setMonths] = useState(props.value?.months ?? 0);
   const [days, setDays] = useState(props.value?.days ?? 0);
@@ -590,14 +574,7 @@ type StructEditorProps = {
 };
 
 function StructEditor(props: StructEditorProps): ReactElement {
-  // Clean up validation on unmount
-  useEffect(() => {
-    return (): void => {
-      if (props.validationId) {
-        clearValidationErrors(props.validationId);
-      }
-    };
-  }, [props.validationId]);
+  // Struct editor delegates validation to child editors
   const { structDeclaration, value, onValueChange } = props;
   const fields = structDeclaration.fields;
 
@@ -635,6 +612,11 @@ function StructEditor(props: StructEditorProps): ReactElement {
                   onValueChange={(newValue) =>
                     handleFieldChange(fieldName, newValue.value!.value)
                   }
+                  validationId={
+                    props.validationId
+                      ? `${props.validationId}_field_${fieldName}`
+                      : undefined
+                  }
                 />
               </td>
             </tr>
@@ -660,14 +642,7 @@ type ArrayEditorProps = {
 };
 
 function ArrayEditor(props: ArrayEditorProps): ReactElement {
-  // Clean up validation on unmount
-  useEffect(() => {
-    return (): void => {
-      if (props.validationId) {
-        clearValidationErrors(props.validationId);
-      }
-    };
-  }, [props.validationId]);
+  // Array editor delegates validation to child editors
   const { elementType, value = [], onValueChange } = props;
 
   const handleAdd = (): void => {
@@ -728,6 +703,11 @@ function ArrayEditor(props: ArrayEditorProps): ReactElement {
               onValueChange={(newValue) =>
                 handleUpdate(index, newValue.value!.value)
               }
+              validationId={
+                props.validationId
+                  ? `${props.validationId}_item_${index}`
+                  : undefined
+              }
             />
           </div>
         ))}
@@ -750,14 +730,7 @@ function runtimeValueToTestIo(typ: Typ, value: Option<RuntimeValue>): TestIo {
 }
 
 function EnumEditor(props: EnumEditorProps): ReactElement {
-  // Clean up validation on unmount
-  useEffect(() => {
-    return (): void => {
-      if (props.validationId) {
-        clearValidationErrors(props.validationId);
-      }
-    };
-  }, [props.validationId]);
+  // Enum editor delegates validation to child ValueEditor when needed
   // Note that in Catala, an enum should always have at least 1 constructor
   // so dereferencing the first array element is valid
   const [currentCtor, setCurrentCtor] = useState(
@@ -790,6 +763,11 @@ function EnumEditor(props: EnumEditorProps): ReactElement {
           onValueChange={(newValue: TestIo): void => {
             props.onValueChange(currentCtor, newValue.value ?? null);
           }}
+          validationId={
+            props.validationId
+              ? `${props.validationId}_value_${currentCtor}`
+              : undefined
+          }
         />
       )}
     </div>

--- a/src/ValueEditors.tsx
+++ b/src/ValueEditors.tsx
@@ -39,10 +39,7 @@ function ValidationErrorDisplay({
   return (
     <div className="validation-errors">
       {errors.map((error, index) => (
-        <div
-          key={index}
-          className={`validation-error validation-${error.severity}`}
-        >
+        <div key={index} className="validation-error">
           {error.message}
         </div>
       ))}

--- a/src/ValueEditors.tsx
+++ b/src/ValueEditors.tsx
@@ -248,6 +248,7 @@ function IntEditor(props: IntEditorProps): ReactElement {
     onValidChange: props.onValueChange,
     validationId,
     parseValue: Number,
+    debounceMs: 300, // Shorter debounce for numbers
   });
 
   return (
@@ -318,6 +319,7 @@ function DateEditor(props: DateEditorProps): ReactElement {
     },
     validationId,
     parseValue: (value) => value,
+    debounceMs: 300, // Shorter debounce for dates
   });
 
   // Custom change handler for dates to update immediately
@@ -375,6 +377,7 @@ function RatEditor(props: RatEditorProps): ReactElement {
     onValidChange: props.onValueChange,
     validationId,
     parseValue: Number,
+    debounceMs: 300, // Shorter debounce for numbers
   });
 
   return (
@@ -401,13 +404,20 @@ type BoolEditorProps = {
 };
 
 function BoolEditor(props: BoolEditorProps): ReactElement {
-  // Boolean selects don't need validation as they're constrained by the select options
+  // Boolean selects don't need validation for correctness, but we want to trigger
+  // parent validation immediately on change
   return (
     <div className="value-editor">
       <select
         value={props.value?.toString() ?? ''}
         onChange={(evt): void => {
+          // Immediately update the value since boolean selects are always valid
           props.onValueChange(evt.target.value === 'true');
+
+          // If there's a validationId, clear any errors
+          if (props.validationId) {
+            clearValidationErrors(props.validationId);
+          }
         }}
       >
         <option value="false">false</option>
@@ -453,7 +463,14 @@ function DurationEditor(props: DurationEditorProps): ReactElement {
         setDays(newValue);
         break;
     }
+
+    // Immediately update the value
     props.onValueChange({ years, months, days, [field]: newValue });
+
+    // If there's a validationId, clear any errors
+    if (props.validationId) {
+      clearValidationErrors(props.validationId);
+    }
   };
 
   return (
@@ -527,6 +544,7 @@ function MoneyEditor(props: MoneyEditorProps): ReactElement {
     onValidChange: (value) => props.onValueChange(parseMoneyValue(value)),
     validationId,
     parseValue: (value) => value, // We'll handle the parsing in onValidChange
+    debounceMs: 300, // Shorter debounce for money
   });
 
   // Custom blur handler to format the value

--- a/src/components/ValidationErrorDisplay.tsx
+++ b/src/components/ValidationErrorDisplay.tsx
@@ -1,0 +1,23 @@
+import { type ReactElement } from 'react';
+import type { ValidationError } from '../validation';
+
+/**
+ * Component to display validation errors
+ */
+export function ValidationErrorDisplay({
+  errors,
+}: {
+  errors: ValidationError[];
+}): ReactElement | null {
+  if (errors.length === 0) return null;
+
+  return (
+    <div className="validation-errors">
+      {errors.map((error, index) => (
+        <div key={index} className="validation-error">
+          {error.message}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/generated/test_case.ts
+++ b/src/generated/test_case.ts
@@ -131,7 +131,7 @@ export type FileSelection = {
 
 export type UpMessage =
 | { kind: 'Ready' }
-| { kind: 'Edit'; value: TestList }
+| { kind: 'GuiEdit'; value: TestList }
 | { kind: 'OpenInTextEditor' }
 | { kind: 'TestRunRequest'; value: TestRunRequest }
 | { kind: 'TestGenerateRequest'; value: TestGenerateRequest }
@@ -562,8 +562,8 @@ export function writeUpMessage(x: UpMessage, context: any = x): any {
   switch (x.kind) {
     case 'Ready':
       return 'Ready'
-    case 'Edit':
-      return ['Edit', writeTestList(x.value, x)]
+    case 'GuiEdit':
+      return ['GuiEdit', writeTestList(x.value, x)]
     case 'OpenInTextEditor':
       return 'OpenInTextEditor'
     case 'TestRunRequest':
@@ -592,8 +592,8 @@ export function readUpMessage(x: any, context: any = x): UpMessage {
   else {
     _atd_check_json_tuple(2, x, context)
     switch (x[0]) {
-      case 'Edit':
-        return { kind: 'Edit', value: readTestList(x[1], x) }
+      case 'GuiEdit':
+        return { kind: 'GuiEdit', value: readTestList(x[1], x) }
       case 'TestRunRequest':
         return { kind: 'TestRunRequest', value: readTestRunRequest(x[1], x) }
       case 'TestGenerateRequest':

--- a/src/hooks/useValidatedInput.ts
+++ b/src/hooks/useValidatedInput.ts
@@ -1,0 +1,90 @@
+import { useState, useEffect, useRef } from 'react';
+import type {
+  ValidationError} from '../validation';
+import {
+  registerValidationErrors,
+  clearValidationErrors,
+} from '../validation';
+
+/**
+ * Custom hook to handle validated input fields
+ */
+export function useValidatedInput<T>({
+  initialValue,
+  validator,
+  onValidChange,
+  validationId,
+  parseValue,
+}: {
+  initialValue: T | undefined;
+  validator: (value: string) => ValidationError[];
+  onValidChange: (value: T) => void;
+  validationId: string;
+  parseValue: (value: string) => T;
+}): {
+  inputValue: string;
+  errors: ValidationError[];
+  handleChange: (evt: React.ChangeEvent<HTMLInputElement>) => void;
+  handleBlur: () => void;
+  handleKeyDown: (evt: React.KeyboardEvent<HTMLInputElement>) => void;
+  inputRef: React.RefObject<HTMLInputElement>;
+} {
+  const [inputValue, setInputValue] = useState(
+    initialValue !== null && initialValue !== undefined
+      ? initialValue.toString()
+      : ''
+  );
+  const [errors, setErrors] = useState<ValidationError[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Update internal state when props change
+  useEffect(() => {
+    if (initialValue !== undefined && initialValue !== null) {
+      setInputValue(initialValue.toString());
+    }
+  }, [initialValue]);
+
+  const handleChange = (evt: React.ChangeEvent<HTMLInputElement>): void => {
+    const newValue = evt.target.value;
+    setInputValue(newValue);
+
+    // Clear errors during typing for better UX
+    if (errors.length > 0) {
+      setErrors([]);
+      clearValidationErrors(validationId);
+    }
+  };
+
+  const handleBlur = (): void => {
+    const validationErrors = validator(inputValue);
+    setErrors(validationErrors);
+    registerValidationErrors(validationId, validationErrors);
+
+    // If valid, update the value
+    if (validationErrors.length === 0 && inputValue.trim() !== '') {
+      onValidChange(parseValue(inputValue));
+    }
+  };
+
+  const handleKeyDown = (evt: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (evt.key === 'Enter') {
+      inputRef.current?.blur();
+    }
+  };
+
+  // Clean up validation on unmount
+  useEffect(() => {
+    return () => {
+      clearValidationErrors(validationId);
+    };
+  }, [validationId]);
+
+  return {
+    inputValue,
+    errors,
+    handleChange,
+    handleBlur,
+    handleKeyDown,
+    inputRef,
+  };
+}

--- a/src/style.css
+++ b/src/style.css
@@ -676,3 +676,23 @@
   color: var(--vscode-descriptionForeground);
   font-size: 12px;
 }
+/* Validation styles */
+.has-validation-error {
+  border: 1px solid #f44336 !important;
+  background-color: rgba(244, 67, 54, 0.05);
+}
+
+.validation-errors {
+  margin-top: 4px;
+  font-size: 12px;
+}
+
+.validation-error {
+  color: #f44336;
+  margin-bottom: 2px;
+}
+
+.validation-warning {
+  color: #ff9800;
+  margin-bottom: 2px;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -691,8 +691,3 @@
   color: #f44336;
   margin-bottom: 2px;
 }
-
-.validation-warning {
-  color: #ff9800;
-  margin-bottom: 2px;
-}

--- a/src/testCaseEditor.ts
+++ b/src/testCaseEditor.ts
@@ -106,7 +106,7 @@ export class TestCaseEditorProvider implements vscode.CustomTextEditorProvider {
           });
           break;
         }
-        case 'Edit': {
+        case 'GuiEdit': {
           logger.log('Got edit from webview');
           // re-emit catala text file from ATD test definitions
           const newTextBuffer = atdToCatala(typed_msg.value, lang);

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -50,13 +50,11 @@ export function clearValidationErrors(id: string): void {
 }
 
 // Validate a numeric input
-export function validateNumeric(
-  value: string,
-  options: { isInteger?: boolean; min?: number; max?: number } = {}
-): ValidationResult {
+export function validateNumeric(value: string): ValidationResult {
   const errors: ValidationError[] = [];
-  const numValue = parseFloat(value);
 
+  // HTML5 input type="number" validation already handles most cases
+  // We just need to check for empty values and specific constraints
   if (value.trim() === '') {
     errors.push({
       message: 'Value cannot be empty',
@@ -64,6 +62,9 @@ export function validateNumeric(
     return { isValid: false, errors };
   }
 
+  const numValue = parseFloat(value);
+
+  // This should rarely happen with HTML5 inputs, but just in case
   if (isNaN(numValue)) {
     errors.push({
       message: 'Value must be a number',
@@ -71,27 +72,9 @@ export function validateNumeric(
     return { isValid: false, errors };
   }
 
-  if (options.isInteger && !Number.isInteger(numValue)) {
-    errors.push({
-      message: 'Value must be an integer',
-    });
-  }
-
-  if (options.min !== undefined && numValue < options.min) {
-    errors.push({
-      message: `Value must be at least ${options.min}`,
-    });
-  }
-
-  if (options.max !== undefined && numValue > options.max) {
-    errors.push({
-      message: `Value must be at most ${options.max}`,
-    });
-  }
-
   return {
-    isValid: errors.length === 0,
-    errors,
+    isValid: true,
+    errors: [],
   };
 }
 
@@ -130,10 +113,11 @@ export function validateMoney(value: string): ValidationResult {
     return { isValid: false, errors };
   }
 
-  const regex = /^\d+(\.\d{1,2})?$/;
-  if (!regex.test(value)) {
+  // HTML5 input type="number" with step="0.01" handles most validation
+  const numValue = parseFloat(value);
+  if (isNaN(numValue) || numValue < 0) {
     errors.push({
-      message: 'Invalid money format (use format: 123.45)',
+      message: 'Please enter a valid monetary amount',
     });
   }
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,0 +1,171 @@
+// Types for validation
+export type ValidationError = {
+  message: string;
+  severity: 'error' | 'warning';
+};
+
+export type ValidationResult = {
+  isValid: boolean;
+  errors: ValidationError[];
+};
+
+// Map to store validation errors by component ID
+export type ValidationMap = Map<string, ValidationError[]>;
+
+// Global validation state
+export const validationState: {
+  errors: ValidationMap;
+  hasErrors: boolean;
+} = {
+  errors: new Map(),
+  hasErrors: false,
+};
+
+// Generate a unique ID for validation tracking
+export function generateValidationId(prefix: string): string {
+  return `${prefix}_${Math.random().toString(36).substring(2, 9)}`;
+}
+
+// Register validation errors
+export function registerValidationErrors(
+  id: string,
+  errors: ValidationError[]
+): void {
+  if (errors.length > 0) {
+    validationState.errors.set(id, errors);
+    validationState.hasErrors = true;
+  } else {
+    validationState.errors.delete(id);
+    validationState.hasErrors = Array.from(
+      validationState.errors.values()
+    ).some((errs) => errs.length > 0);
+  }
+}
+
+// Clear validation errors for a component
+export function clearValidationErrors(id: string): void {
+  validationState.errors.delete(id);
+  validationState.hasErrors = Array.from(validationState.errors.values()).some(
+    (errs) => errs.length > 0
+  );
+}
+
+// Validate a numeric input
+export function validateNumeric(
+  value: string,
+  options: { isInteger?: boolean; min?: number; max?: number } = {}
+): ValidationResult {
+  const errors: ValidationError[] = [];
+  const numValue = parseFloat(value);
+
+  if (value.trim() === '') {
+    errors.push({
+      message: 'Value cannot be empty',
+      severity: 'error',
+    });
+    return { isValid: false, errors };
+  }
+
+  if (isNaN(numValue)) {
+    errors.push({
+      message: 'Value must be a number',
+      severity: 'error',
+    });
+    return { isValid: false, errors };
+  }
+
+  if (options.isInteger && !Number.isInteger(numValue)) {
+    errors.push({
+      message: 'Value must be an integer',
+      severity: 'error',
+    });
+  }
+
+  if (options.min !== undefined && numValue < options.min) {
+    errors.push({
+      message: `Value must be at least ${options.min}`,
+      severity: 'error',
+    });
+  }
+
+  if (options.max !== undefined && numValue > options.max) {
+    errors.push({
+      message: `Value must be at most ${options.max}`,
+      severity: 'error',
+    });
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  };
+}
+
+// Validate a date input
+export function validateDate(value: string): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  if (value.trim() === '') {
+    errors.push({
+      message: 'Date cannot be empty',
+      severity: 'error',
+    });
+    return { isValid: false, errors };
+  }
+
+  const date = new Date(value);
+  if (isNaN(date.getTime())) {
+    errors.push({
+      message: 'Invalid date format',
+      severity: 'error',
+    });
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  };
+}
+
+// Validate a money input
+export function validateMoney(value: string): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  if (value.trim() === '') {
+    errors.push({
+      message: 'Value cannot be empty',
+      severity: 'error',
+    });
+    return { isValid: false, errors };
+  }
+
+  const regex = /^-?\d+(\.\d{1,2})?$/;
+  if (!regex.test(value)) {
+    errors.push({
+      message: 'Invalid money format (use format: 123.45)',
+      severity: 'error',
+    });
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  };
+}
+
+// Trigger validation for all components
+export function validateAll(): boolean {
+  // This function would be called before saving
+  return !validationState.hasErrors;
+}
+
+// Focus on the first error element (to be implemented with refs)
+export function focusFirstError(): void {
+  // This would require DOM refs to be implemented
+  console.log('Would focus on first error');
+}
+
+// Helper to extract validation errors for display
+export function getValidationErrorsForDisplay(id: string): ValidationError[] {
+  return validationState.errors.get(id) ?? [];
+}

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,7 +1,6 @@
 // Types for validation
 export type ValidationError = {
   message: string;
-  severity: 'error' | 'warning';
 };
 
 export type ValidationResult = {
@@ -61,7 +60,6 @@ export function validateNumeric(
   if (value.trim() === '') {
     errors.push({
       message: 'Value cannot be empty',
-      severity: 'error',
     });
     return { isValid: false, errors };
   }
@@ -69,7 +67,6 @@ export function validateNumeric(
   if (isNaN(numValue)) {
     errors.push({
       message: 'Value must be a number',
-      severity: 'error',
     });
     return { isValid: false, errors };
   }
@@ -77,21 +74,18 @@ export function validateNumeric(
   if (options.isInteger && !Number.isInteger(numValue)) {
     errors.push({
       message: 'Value must be an integer',
-      severity: 'error',
     });
   }
 
   if (options.min !== undefined && numValue < options.min) {
     errors.push({
       message: `Value must be at least ${options.min}`,
-      severity: 'error',
     });
   }
 
   if (options.max !== undefined && numValue > options.max) {
     errors.push({
       message: `Value must be at most ${options.max}`,
-      severity: 'error',
     });
   }
 
@@ -108,7 +102,6 @@ export function validateDate(value: string): ValidationResult {
   if (value.trim() === '') {
     errors.push({
       message: 'Date cannot be empty',
-      severity: 'error',
     });
     return { isValid: false, errors };
   }
@@ -117,7 +110,6 @@ export function validateDate(value: string): ValidationResult {
   if (isNaN(date.getTime())) {
     errors.push({
       message: 'Invalid date format',
-      severity: 'error',
     });
   }
 
@@ -134,7 +126,6 @@ export function validateMoney(value: string): ValidationResult {
   if (value.trim() === '') {
     errors.push({
       message: 'Value cannot be empty',
-      severity: 'error',
     });
     return { isValid: false, errors };
   }
@@ -143,7 +134,6 @@ export function validateMoney(value: string): ValidationResult {
   if (!regex.test(value)) {
     errors.push({
       message: 'Invalid money format (use format: 123.45)',
-      severity: 'error',
     });
   }
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -130,7 +130,7 @@ export function validateMoney(value: string): ValidationResult {
     return { isValid: false, errors };
   }
 
-  const regex = /^-?\d+(\.\d{1,2})?$/;
+  const regex = /^\d+(\.\d{1,2})?$/;
   if (!regex.test(value)) {
     errors.push({
       message: 'Invalid money format (use format: 123.45)',

--- a/test-case-parser/test_case.atd
+++ b/test-case-parser/test_case.atd
@@ -127,7 +127,7 @@ type file_selection = {
 
 type up_message = [
   | Ready
-  | Edit of test_list
+  | GuiEdit of test_list
   | OpenInTextEditor
   | TestRunRequest of test_run_request
   | TestGenerateRequest of test_generate_request


### PR DESCRIPTION
Just open for discussion, not ready yet...

# Inputs in the GUI plugin

## Problem statement

The GUI plugin has some properties and desirable features that relate to text editors, and
some that relate to web forms. Those properties sometimes contradict. Both must be balanced.

One constraint of our chosen test case GUI design (use a simplified AST to generate textual test cases)
is that we cannot generate (and therefore save) syntactically incorrect catala, nor can we parse it.

Beyond syntax, we also rely on being able to do type introspection and get representations of
other modules...

This makes our editor obviously less robust than text (we can always load and save a text file,
even when it does not represent a syntactically valid catala program)

## Principles

- We should not get in the way of the user's keystrokes (validate later)
- Fail on save may be unavoidable (we can only generate syntactically correct programs) -- but should be limited

## Possible implementation sketch

- We cannot hold/override the save method, so failing on save is not an option.

So, when saving, we should save the latest correct value for value editors (and retain the user input ?)

So we're going to
  - collect error as edition happens (quiescence, blur, ...)
  - display feedback to the user continuously but unobtrusively if possible
  - when saving, 
    - attempt to trigger a validation for the tree of tests? (for the value editors, really...)
      - so we should be able to trigger validation from the top as well as from the bottom? (not sure)
      - also we need to clear errors when the user has entered a valid value
      (using the components' reference in a map? Whenever a onValueChange event happens,
      the errors should be cleared for a given ValueEditor etc.)
    - if there are errors, put the first error into view

### (?) Events that should trigger a validation (?)
  - save ? [focus on first error] 
  - blur ?
  - quiescence period ? [do not focus on first error ?]


### (?) What happens if validation does not succeed (?)
  - window hide/restore : we should not lose edits -> how to ensure that?

## Other notes

- In the current implementation, the "changed/dirty" mark in VS code (white dot in the file tab) is only shown
when an edit has been sent and accepted upwards...

## References

https://www.smashingmagazine.com/2022/09/inline-validation-web-forms-ux/ - a nice set of recommendations for form validation.