### PR TITLE
fix gui list reorder issue

### DIFF
--- a/src/ValueEditors.tsx
+++ b/src/ValueEditors.tsx
@@ -553,7 +553,7 @@ function StructEditor(props: StructEditorProps): ReactElement {
                 isCollapsed={isCollapsible(fieldType) ? isFolded : undefined}
                 onToggleCollapse={
                   isCollapsible(fieldType)
-                    ? () => setIsFolded(!isFolded)
+                    ? (): void => setIsFolded(!isFolded)
                     : undefined
                 }
               >
@@ -591,7 +591,7 @@ function ArrayEditor(props: ArrayEditorProps): ReactElement {
     onValueChange([...value, newValue]);
   };
 
-  const handleUpdate = (index: number, newValue: RuntimeValue) => {
+  const handleUpdate = (index: number, newValue: RuntimeValue): void => {
     const updatedArray = [...value];
     updatedArray[index] = newValue;
     onValueChange(updatedArray);
@@ -613,7 +613,7 @@ function ArrayEditor(props: ArrayEditorProps): ReactElement {
     <div className="array-editor">
       <div className="array-items">
         {value.map((item, index) => (
-          <div key={index} className="array-item">
+          <div key={Math.random()} className="array-item">
             <div className="array-item-controls">
               <button
                 className="array-move-up"


### PR DESCRIPTION
This fixes a GUI reordering issue.

Note that the fix is explicitely mentioned as a bad practice in the react documentation! 

(see https://react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key )

But, given our current model, there are not many options available: 

The react docs state

> Where to get your key
> 
> Different sources of data provide different sources of keys:
> 
>     Data from a database: If your data is coming from a database, you can use the database keys/IDs, which are unique by nature.
>     Locally generated data: If your data is generated and persisted locally (e.g. notes in a note-taking app), use an incrementing counter, [crypto.randomUUID()](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) or a package like [uuid](https://www.npmjs.com/package/uuid) when creating items.
> 
> Rules of keys
> 
>     Keys must be unique among siblings. However, it’s okay to use the same keys for JSX nodes in different arrays.
>     Keys must not change or that defeats their purpose! Don’t generate them while rendering.

Here, we do not have database-generated ids and we could not store identifiers easily as metadata (that could change with attribute support however, which might be the correct fix in the end)

The docs also state that

> Pitfall
> 
> You might be tempted to use an item’s index in the array as its key. In fact, that’s what React will use if you don’t specify a key at all. But the order in which you render items will change over time if an item is inserted, deleted, or if the array gets reordered. Index as a key often leads to subtle and confusing bugs.
> 
> Similarly, do not generate keys on the fly, e.g. with key={Math.random()}. This will cause keys to never match up between renders, leading to all your components and DOM being recreated every time. Not only is this slow, but it will also lose any user input inside the list items. Instead, use a stable ID based on the data.

Indeed we were previously using array indices as ids but since React only uses those as hints and should be able to reconcile UI trees automatically, the fact that this could lead to "subtle and confusing bugs" is mysterious to me.

In this instance, it is more important to be correct than fast so we use random IDs for now, and should transition to attribute-stored IDs when we land attribute support in catala?