### PR TITLE
Add test description 

### DIFF
--- a/src/TestEditor.tsx
+++ b/src/TestEditor.tsx
@@ -1,3 +1,4 @@
+import type { ChangeEvent } from 'react';
 import { type ReactElement, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import {
@@ -30,7 +31,15 @@ export default function TestEditor(props: Props): ReactElement {
     });
   }
 
+  function onDescriptionChange(event: ChangeEvent<HTMLTextAreaElement>): void {
+    props.onTestChange({
+      ...props.test,
+      description: event.target.value,
+    });
+  }
+
   const [isCollapsed, setIsCollapsed] = useState(false);
+  const [description, setDescription] = useState(props.test.description);
 
   return (
     <div className="test-editor">
@@ -76,6 +85,24 @@ export default function TestEditor(props: Props): ReactElement {
         className="test-editor-content"
         style={{ display: isCollapsed ? 'none' : 'block' }}
       >
+        <div className="test-section">
+          <h2 className="test-section-title">
+            <FormattedMessage
+              id="testEditor.description"
+              defaultMessage="Description"
+            />
+          </h2>
+          <div className="test-description-editor">
+            <textarea
+              value={description}
+              onChange={(evt) => setDescription(evt.target.value)}
+              onBlur={onDescriptionChange}
+              placeholder="Enter test description..."
+              rows={3}
+              className="test-description-textarea"
+            />
+          </div>
+        </div>
         <div className="test-section">
           <h2 className="test-section-title">
             <FormattedMessage id="testEditor.inputs" />

--- a/src/TestFileEditor.tsx
+++ b/src/TestFileEditor.tsx
@@ -153,7 +153,6 @@ export default function TestFileEditor({
         const idx = state.tests.findIndex(
           (tst) => tst.testing_scope === newValue.testing_scope
         );
-        console.log(`test changed at index ${idx}`);
         const newTestState = [...state.tests];
         newTestState[idx] = newValue; //we can do away with this when array.with() becomes widely available
         console.log('old test state');

--- a/src/generated/test_case.ts
+++ b/src/generated/test_case.ts
@@ -78,6 +78,7 @@ export type RuntimeValueRaw =
 | { kind: 'Array'; value: RuntimeValue[] }
 
 export type AttrDef =
+| { kind: 'TestDescription'; value: string }
 | { kind: 'Uid'; value: string }
 
 export type RuntimeValue = {
@@ -104,6 +105,7 @@ export type Test = {
   tested_scope: ScopeDef;
   test_inputs: TestInputs;
   test_outputs: TestOutputs;
+  description: string;
 }
 
 export type TestList = Test[]
@@ -371,6 +373,8 @@ export function readRuntimeValueRaw(x: any, context: any = x): RuntimeValueRaw {
 
 export function writeAttrDef(x: AttrDef, context: any = x): any {
   switch (x.kind) {
+    case 'TestDescription':
+      return ['TestDescription', _atd_write_string(x.value, x)]
     case 'Uid':
       return ['Uid', _atd_write_string(x.value, x)]
   }
@@ -379,6 +383,8 @@ export function writeAttrDef(x: AttrDef, context: any = x): any {
 export function readAttrDef(x: any, context: any = x): AttrDef {
   _atd_check_json_tuple(2, x, context)
   switch (x[0]) {
+    case 'TestDescription':
+      return { kind: 'TestDescription', value: _atd_read_string(x[1], x) }
     case 'Uid':
       return { kind: 'Uid', value: _atd_read_string(x[1], x) }
     default:
@@ -451,6 +457,7 @@ export function writeTest(x: Test, context: any = x): any {
     'tested_scope': _atd_write_required_field('Test', 'tested_scope', writeScopeDef, x.tested_scope, x),
     'test_inputs': _atd_write_required_field('Test', 'test_inputs', writeTestInputs, x.test_inputs, x),
     'test_outputs': _atd_write_required_field('Test', 'test_outputs', writeTestOutputs, x.test_outputs, x),
+    'description': _atd_write_required_field('Test', 'description', _atd_write_string, x.description, x),
   };
 }
 
@@ -460,6 +467,7 @@ export function readTest(x: any, context: any = x): Test {
     tested_scope: _atd_read_required_field('Test', 'tested_scope', readScopeDef, x['tested_scope'], x),
     test_inputs: _atd_read_required_field('Test', 'test_inputs', readTestInputs, x['test_inputs'], x),
     test_outputs: _atd_read_required_field('Test', 'test_outputs', readTestOutputs, x['test_outputs'], x),
+    description: _atd_read_required_field('Test', 'description', _atd_read_string, x['description'], x),
   };
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -749,3 +749,14 @@
   color: var(--vscode-descriptionForeground);
   font-size: 12px;
 }
+
+.test-description-editor {
+  width: 100%;
+}
+
+.test-description-textarea {
+  background: var(--vscode-editor-background);
+  color: var(--vscode-input-foreground);
+  width: 100%;
+  max-width: 600px;
+}

--- a/test-case-parser/test_case.atd
+++ b/test-case-parser/test_case.atd
@@ -68,7 +68,10 @@ type runtime_value_raw = [
 ] <ocaml repr="classic">
 
 (* to be extended with free-form descriptions, etc. *)
-type attr_def = [Uid of string] <ocaml repr="classic">
+type attr_def = [
+  | TestDescription of string
+  | Uid of string
+  ] <ocaml repr="classic">
 
 type runtime_value = {
   value: runtime_value_raw;
@@ -92,9 +95,10 @@ type test_outputs = (string * test_io) list <json repr="object"> <ts repr="map">
 
 type test = {
   testing_scope: string;
-  tested_scope : scope_def;
-  test_inputs : test_inputs;
-  test_outputs : test_outputs;
+  tested_scope: scope_def;
+  test_inputs: test_inputs;
+  test_outputs: test_outputs;
+  description: string;
 }
 
 type test_list = test list

--- a/test-case-parser/testcase.ml
+++ b/test-case-parser/testcase.ml
@@ -85,11 +85,12 @@ let register () =
     ~doc:"Catala plugin for the handling of scope test cases" ~man
     [cmd_generate; cmd_read; cmd_run; cmd_write; cmd_list_scopes];
   Driver.Plugin.register_attribute ~plugin:"testcase" ~path:["uid"] ~contexts:[Desugared.Name_resolution.Expression]
-    @@ fun ~pos:_ value -> match value with
+    @@ (fun ~pos:_ value -> match value with
     | Shared_ast.String (s, _pos) -> Some (Test_case_parser_lib.Uid s)
-    | _ -> failwith "unexpected UID value"
+    | _ -> failwith "unexpected UID value");
+  Driver.Plugin.register_attribute ~plugin:"testcase" ~path:["test_description"] ~contexts:[Desugared.Name_resolution.ScopeDecl]
+    @@ fun ~pos:_ value -> match value with
+    | Shared_ast.String (s, _pos) -> Some (Test_case_parser_lib.TestDescription s)
+    | _ -> failwith "unexpected test description"
 
-(* For now, can be invoked through `catala test-case-parser --plugin-dir
-   _build/default/ <FILE>` but we need to figure out distribution through vscode
-   or otherwise. *)
 let () = register ()


### PR DESCRIPTION
This PR adds a description to the test objects (as an attribute).

Descriptions are updated on blur to keep a responsive UI (add a quiescence period or something...?)

Test description is escaped through ocaml's `String.quote` -- it might be worth adapting attribute strings to dovetail with that.