### PR TITLE
Input quiescence

### DIFF
--- a/src/TestEditor.tsx
+++ b/src/TestEditor.tsx
@@ -32,9 +32,11 @@ export default function TestEditor(props: Props): ReactElement {
   }
 
   function onDescriptionChange(event: ChangeEvent<HTMLTextAreaElement>): void {
+    const newDescription = event.target.value;
+    setDescription(newDescription);
     props.onTestChange({
       ...props.test,
-      description: event.target.value,
+      description: newDescription,
     });
   }
 
@@ -95,8 +97,7 @@ export default function TestEditor(props: Props): ReactElement {
           <div className="test-description-editor">
             <textarea
               value={description}
-              onChange={(evt) => setDescription(evt.target.value)}
-              onBlur={onDescriptionChange}
+              onChange={onDescriptionChange}
               placeholder="Enter test description..."
               rows={3}
               className="test-description-textarea"

--- a/src/TestEditor.tsx
+++ b/src/TestEditor.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent } from 'react';
-import { type ReactElement, useState } from 'react';
+import { type ReactElement, useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import {
   type Test,
@@ -42,6 +42,10 @@ export default function TestEditor(props: Props): ReactElement {
 
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [description, setDescription] = useState(props.test.description);
+
+  useEffect(() => {
+    setDescription(props.test.description);
+  }, [props.test.description]);
 
   return (
     <div className="test-editor">

--- a/src/TestFileEditor.tsx
+++ b/src/TestFileEditor.tsx
@@ -66,8 +66,6 @@ export default function TestFileEditor({
     step: 'selectFile',
   });
   const modalContentRef = useRef<HTMLDivElement>(null);
-  const [isUIDisabled, setIsUIDisabled] = useState(false);
-  const activeElementRef = useRef<Element | null>(null);
 
   useEffect(() => {
     if (modalState.isOpen && modalContentRef.current) {
@@ -268,16 +266,6 @@ export default function TestFileEditor({
       switch (message.kind) {
         case 'Update':
           setState(parseResultsToUiState(message.value));
-          setIsUIDisabled(false);
-          // Restaurer le focus après la mise à jour
-          setTimeout(() => {
-            if (
-              activeElementRef.current &&
-              activeElementRef.current instanceof HTMLElement
-            ) {
-              activeElementRef.current.focus();
-            }
-          }, 0);
           break;
         case 'TestRunResults': {
           const results = message.value;
@@ -305,11 +293,6 @@ export default function TestFileEditor({
             filename: message.value.filename,
             availableScopes: message.value.available_scopes,
           }));
-          break;
-        case 'DisableUI':
-          // Sauvegarder l'élément actif avant de désactiver l'interface
-          activeElementRef.current = document.activeElement;
-          setIsUIDisabled(true);
           break;
         default:
           assertUnreachable(message);
@@ -356,10 +339,7 @@ export default function TestFileEditor({
       }
       return (
         <CancelSourceUpdateProvider onCancelSourceUpdate={cancelSourceUpdate}>
-          <div
-            className="test-editor-container"
-            {...(isUIDisabled ? { inert: '' } : {})}
-          >
+          <div className="test-editor-container">
             <div className="test-editor-top-bar">
               <button className="test-editor-add-button" onClick={onAddNewTest}>
                 <span className="codicon codicon-add"></span>

--- a/src/TestFileEditor.tsx
+++ b/src/TestFileEditor.tsx
@@ -31,7 +31,8 @@ type UIState =
   | { state: 'initializing' }
   | { state: 'error'; message: string }
   | { state: 'emptyTestListMismatch' }
-  | { state: 'success'; tests: TestList };
+  | { state: 'success'; tests: TestList }
+  | { state: 'standby'; tests: TestList };
 
 type TestRunState = {
   [scope: string]: {
@@ -149,17 +150,22 @@ export default function TestFileEditor({
 
   const onTestChange = useCallback(
     (newValue: Test): void => {
-      if (state.state === 'success') {
+      if (state.state === 'success' || state.state === 'standby') {
         const idx = state.tests.findIndex(
           (tst) => tst.testing_scope === newValue.testing_scope
         );
         const newTestState = [...state.tests];
         newTestState[idx] = newValue; //we can do away with this when array.with() becomes widely available
-        console.log('old test state');
-        console.log(state.tests);
-        console.log('new test state');
-        console.log(newTestState);
 
+        // Optimistically update the state
+        setState((prevState) => {
+          if (prevState.state === 'success' || prevState.state === 'standby') {
+            return { ...prevState, tests: newTestState };
+          }
+          return prevState;
+        });
+
+        // Send the update to the backend
         vscode.postMessage(
           writeUpMessage({
             kind: 'GuiEdit',
@@ -259,6 +265,11 @@ export default function TestFileEditor({
         case 'Update':
           setState(parseResultsToUiState(message.value));
           break;
+        case 'StandBy':
+          if (state.state === 'success') {
+            setState({ state: 'standby', tests: state.tests });
+          }
+          break;
         case 'TestRunResults': {
           const results = message.value;
           setTestRunState((prev) => {
@@ -312,7 +323,9 @@ export default function TestFileEditor({
           <FormattedMessage id="app.initializing" />
         </strong>
       );
+    case 'standby':
     case 'success': {
+      const isDisabled = state.state === 'standby';
       if (state.tests.length === 0) {
         return (
           <>
@@ -330,7 +343,9 @@ export default function TestFileEditor({
         );
       }
       return (
-        <div className="test-editor-container">
+        <div
+          className={`test-editor-container ${isDisabled ? 'disabled' : ''}`}
+        >
           <div className="test-editor-top-bar">
             <button className="test-editor-add-button" onClick={onAddNewTest}>
               <span className="codicon codicon-add"></span>

--- a/src/TestFileEditor.tsx
+++ b/src/TestFileEditor.tsx
@@ -31,8 +31,7 @@ type UIState =
   | { state: 'initializing' }
   | { state: 'error'; message: string }
   | { state: 'emptyTestListMismatch' }
-  | { state: 'success'; tests: TestList }
-  | { state: 'standby'; tests: TestList };
+  | { state: 'success'; tests: TestList };
 
 type TestRunState = {
   [scope: string]: {
@@ -150,7 +149,7 @@ export default function TestFileEditor({
 
   const onTestChange = useCallback(
     (newValue: Test): void => {
-      if (state.state === 'success' || state.state === 'standby') {
+      if (state.state === 'success') {
         const idx = state.tests.findIndex(
           (tst) => tst.testing_scope === newValue.testing_scope
         );
@@ -159,7 +158,7 @@ export default function TestFileEditor({
 
         // Optimistically update the state
         setState((prevState) => {
-          if (prevState.state === 'success' || prevState.state === 'standby') {
+          if (prevState.state === 'success') {
             return { ...prevState, tests: newTestState };
           }
           return prevState;
@@ -265,11 +264,6 @@ export default function TestFileEditor({
         case 'Update':
           setState(parseResultsToUiState(message.value));
           break;
-        case 'StandBy':
-          if (state.state === 'success') {
-            setState({ state: 'standby', tests: state.tests });
-          }
-          break;
         case 'TestRunResults': {
           const results = message.value;
           setTestRunState((prev) => {
@@ -323,9 +317,7 @@ export default function TestFileEditor({
           <FormattedMessage id="app.initializing" />
         </strong>
       );
-    case 'standby':
     case 'success': {
-      const isDisabled = state.state === 'standby';
       if (state.tests.length === 0) {
         return (
           <>
@@ -343,9 +335,7 @@ export default function TestFileEditor({
         );
       }
       return (
-        <div
-          className={`test-editor-container ${isDisabled ? 'disabled' : ''}`}
-        >
+        <div className="test-editor-container">
           <div className="test-editor-top-bar">
             <button className="test-editor-add-button" onClick={onAddNewTest}>
               <span className="codicon codicon-add"></span>

--- a/src/TestFileEditor.tsx
+++ b/src/TestFileEditor.tsx
@@ -66,6 +66,8 @@ export default function TestFileEditor({
     step: 'selectFile',
   });
   const modalContentRef = useRef<HTMLDivElement>(null);
+  const [isUIDisabled, setIsUIDisabled] = useState(false);
+  const activeElementRef = useRef<Element | null>(null);
 
   useEffect(() => {
     if (modalState.isOpen && modalContentRef.current) {
@@ -266,6 +268,16 @@ export default function TestFileEditor({
       switch (message.kind) {
         case 'Update':
           setState(parseResultsToUiState(message.value));
+          setIsUIDisabled(false);
+          // Restaurer le focus après la mise à jour
+          setTimeout(() => {
+            if (
+              activeElementRef.current &&
+              activeElementRef.current instanceof HTMLElement
+            ) {
+              activeElementRef.current.focus();
+            }
+          }, 0);
           break;
         case 'TestRunResults': {
           const results = message.value;
@@ -293,6 +305,11 @@ export default function TestFileEditor({
             filename: message.value.filename,
             availableScopes: message.value.available_scopes,
           }));
+          break;
+        case 'DisableUI':
+          // Sauvegarder l'élément actif avant de désactiver l'interface
+          activeElementRef.current = document.activeElement;
+          setIsUIDisabled(true);
           break;
         default:
           assertUnreachable(message);
@@ -339,7 +356,10 @@ export default function TestFileEditor({
       }
       return (
         <CancelSourceUpdateProvider onCancelSourceUpdate={cancelSourceUpdate}>
-          <div className="test-editor-container">
+          <div
+            className="test-editor-container"
+            {...(isUIDisabled ? { inert: '' } : {})}
+          >
             <div className="test-editor-top-bar">
               <button className="test-editor-add-button" onClick={onAddNewTest}>
                 <span className="codicon codicon-add"></span>

--- a/src/TestFileEditor.tsx
+++ b/src/TestFileEditor.tsx
@@ -159,12 +159,7 @@ export default function TestFileEditor({
         newTestState[idx] = newValue; //we can do away with this when array.with() becomes widely available
 
         // Optimistically update the state
-        setState((prevState) => {
-          if (prevState.state === 'success') {
-            return { ...prevState, tests: newTestState };
-          }
-          return prevState;
-        });
+        setState({ state: 'success', tests: newTestState });
 
         // Send the update to the backend
         vscode.postMessage(
@@ -184,9 +179,11 @@ export default function TestFileEditor({
         const newTestState = state.tests.filter(
           (test) => test.testing_scope !== testScope
         );
-        console.log('Deleting test:', testScope);
-        console.log('New test state:', newTestState);
 
+        // Optimistically update the state
+        setState({ state: 'success', tests: newTestState });
+
+        // Send the deletion to the backend
         vscode.postMessage(
           writeUpMessage({
             kind: 'GuiEdit',

--- a/src/ValueEditors.tsx
+++ b/src/ValueEditors.tsx
@@ -448,8 +448,15 @@ function MoneyEditor(props: MoneyEditorProps): ReactElement {
   const initialValue = // in cents
     runtimeValue?.value.kind === 'Money' ? runtimeValue.value.value : undefined;
 
-  const centsToDisplayValue = (cents: number | undefined): string =>
-    cents !== undefined ? (cents / 100).toFixed(2) : '';
+  const centsToDisplayValue = (cents: number | undefined): string => {
+    if (cents === undefined) {
+      return '';
+    }
+    if (cents % 100 === 0) {
+      return String(cents / 100);
+    }
+    return (cents / 100).toFixed(2);
+  };
 
   const [displayValue, setDisplayValue] = useState(
     centsToDisplayValue(initialValue)
@@ -479,17 +486,6 @@ function MoneyEditor(props: MoneyEditorProps): ReactElement {
     }
   };
 
-  const handleBlur = (): void => {
-    if (!isValidMoney(displayValue)) {
-      // Reset to the last valid value or empty string
-      const resetValue =
-        runtimeValue?.value.kind === 'Money'
-          ? runtimeValue.value.value
-          : undefined;
-      setDisplayValue(centsToDisplayValue(resetValue));
-    }
-  };
-
   return (
     <div className="value-editor money-editor">
       <input
@@ -498,7 +494,6 @@ function MoneyEditor(props: MoneyEditorProps): ReactElement {
         required
         value={displayValue}
         onChange={handleChange}
-        onBlur={handleBlur}
         className={`money-input ${
           displayValue && !isValidMoney(displayValue) ? 'invalid-money' : ''
         }`}

--- a/src/ValueEditors.tsx
+++ b/src/ValueEditors.tsx
@@ -152,17 +152,6 @@ function IntEditor(props: IntEditorProps): ReactElement {
     }
   };
 
-  const handleBlur = (): void => {
-    if (!isValidInt(displayValue)) {
-      // Reset to the last valid value or empty string
-      const resetValue =
-        runtimeValue?.value.kind === 'Integer'
-          ? runtimeValue.value.value
-          : undefined;
-      setDisplayValue(resetValue?.toString() ?? '');
-    }
-  };
-
   return (
     <div className="value-editor int-editor">
       <input
@@ -171,7 +160,6 @@ function IntEditor(props: IntEditorProps): ReactElement {
         required
         value={displayValue}
         onChange={handleChange}
-        onBlur={handleBlur}
         className={`int-input ${
           displayValue && !isValidInt(displayValue) ? 'invalid-int' : ''
         }`}
@@ -237,8 +225,6 @@ function DateEditor(props: DateEditorProps): ReactElement {
     }
   };
 
-  // TODO: Add onBlur validation?
-
   return (
     <div className="value-editor">
       <input type="date" value={internalValue} onChange={handleChange} />
@@ -291,17 +277,6 @@ function RatEditor(props: RatEditorProps): ReactElement {
     }
   };
 
-  const handleBlur = (): void => {
-    if (!isValidRat(displayValue)) {
-      // Reset to the last valid value or empty string
-      const resetValue =
-        runtimeValue?.value.kind === 'Decimal'
-          ? runtimeValue.value.value
-          : undefined;
-      setDisplayValue(resetValue?.toString() ?? '');
-    }
-  };
-
   return (
     <div className="value-editor rat-editor">
       <input
@@ -310,7 +285,6 @@ function RatEditor(props: RatEditorProps): ReactElement {
         required
         value={displayValue}
         onChange={handleChange}
-        onBlur={handleBlur}
         className={`rat-input ${
           displayValue && !isValidRat(displayValue) ? 'invalid-rat' : ''
         }`}

--- a/src/ValueEditors.tsx
+++ b/src/ValueEditors.tsx
@@ -431,7 +431,7 @@ function DurationEditor(props: DurationEditorProps): ReactElement {
   );
 }
 
-const MONEY_PATTERN = /^\d+(\.\d{2})?$/;
+const MONEY_PATTERN = /^\d+(\.\d{1,2})?$/;
 
 function isValidMoney(value: string): boolean {
   return MONEY_PATTERN.test(value);
@@ -454,6 +454,9 @@ function MoneyEditor(props: MoneyEditorProps): ReactElement {
     }
     if (cents % 100 === 0) {
       return String(cents / 100);
+    }
+    if (cents % 10 === 0) {
+      return (cents / 100).toFixed(1);
     }
     return (cents / 100).toFixed(2);
   };

--- a/src/ValueEditors.tsx
+++ b/src/ValueEditors.tsx
@@ -232,7 +232,13 @@ function DateEditor(props: DateEditorProps): ReactElement {
 
   return (
     <div className="value-editor">
-      <input type="date" value={internalValue} onChange={handleChange} />
+      <input
+        type="date"
+        min="0000-01-01"
+        max="9999-12-31"
+        value={internalValue}
+        onChange={handleChange}
+      />
     </div>
   );
 }

--- a/src/ValueEditors.tsx
+++ b/src/ValueEditors.tsx
@@ -1,6 +1,6 @@
 // Editors for a single value type (grouped with a factory function)
 
-import { type ReactElement, useState, useEffect } from 'react';
+import { type ReactElement, useState, useEffect, useRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 import CollapsibleRow from './CollapsibleRow';
 import type {
@@ -130,6 +130,7 @@ function IntEditor(props: IntEditorProps): ReactElement {
   const [displayValue, setDisplayValue] = useState(
     initialValue?.toString() ?? ''
   );
+  const inputRef = useRef<HTMLInputElement>(null);
 
   // Update display value if prop changes externally
   useEffect(() => {
@@ -157,14 +158,24 @@ function IntEditor(props: IntEditorProps): ReactElement {
     }
   };
 
+  const handleBlur = (event: React.FocusEvent<HTMLInputElement>): void => {
+    // If the value is invalid, prevent blur by refocusing
+    if (displayValue && !isValidInt(displayValue)) {
+      event.preventDefault();
+      inputRef.current?.focus();
+    }
+  };
+
   return (
     <div className="value-editor int-editor">
       <input
+        ref={inputRef}
         type="text"
         pattern={INT_PATTERN.source}
         required
         value={displayValue}
         onChange={handleChange}
+        onBlur={handleBlur}
         className={`int-input ${
           displayValue && !isValidInt(displayValue) ? 'invalid-int' : ''
         }`}
@@ -265,6 +276,7 @@ function RatEditor(props: RatEditorProps): ReactElement {
   const [displayValue, setDisplayValue] = useState(
     initialValue?.toString() ?? ''
   );
+  const inputRef = useRef<HTMLInputElement>(null);
 
   // Update display value if prop changes externally
   useEffect(() => {
@@ -302,14 +314,24 @@ function RatEditor(props: RatEditorProps): ReactElement {
     }
   };
 
+  const handleBlur = (event: React.FocusEvent<HTMLInputElement>): void => {
+    // If the value is invalid, prevent blur by refocusing
+    if (displayValue && !isValidRat(displayValue)) {
+      event.preventDefault();
+      inputRef.current?.focus();
+    }
+  };
+
   return (
     <div className="value-editor rat-editor">
       <input
+        ref={inputRef}
         type="text"
         pattern={RAT_PATTERN.source}
         required
         value={displayValue}
         onChange={handleChange}
+        onBlur={handleBlur}
         className={`rat-input ${
           displayValue && !isValidRat(displayValue) ? 'invalid-rat' : ''
         }`}
@@ -464,6 +486,7 @@ function MoneyEditor(props: MoneyEditorProps): ReactElement {
   const [displayValue, setDisplayValue] = useState(
     centsToDisplayValue(initialValue)
   );
+  const inputRef = useRef<HTMLInputElement>(null);
 
   // Update display value if prop changes externally
   useEffect(() => {
@@ -491,14 +514,24 @@ function MoneyEditor(props: MoneyEditorProps): ReactElement {
     }
   };
 
+  const handleBlur = (event: React.FocusEvent<HTMLInputElement>): void => {
+    // If the value is invalid, prevent blur by refocusing
+    if (displayValue && !isValidMoney(displayValue)) {
+      event.preventDefault();
+      inputRef.current?.focus();
+    }
+  };
+
   return (
     <div className="value-editor money-editor">
       <input
+        ref={inputRef}
         type="text"
         pattern={MONEY_PATTERN.source}
         required
         value={displayValue}
         onChange={handleChange}
+        onBlur={handleBlur}
         className={`money-input ${
           displayValue && !isValidMoney(displayValue) ? 'invalid-money' : ''
         }`}

--- a/src/contexts/CancelSourceUpdateContext.tsx
+++ b/src/contexts/CancelSourceUpdateContext.tsx
@@ -1,0 +1,30 @@
+import React, { createContext } from 'react';
+
+export type CancelSourceUpdateCallback = () => void;
+
+export interface ICancelSourceUpdateProviderProps {
+  children: React.ReactNode;
+  onCancelSourceUpdate: CancelSourceUpdateCallback;
+}
+
+// Create context with explicit type, null as initial value
+const CancelSourceUpdateContext =
+  createContext<CancelSourceUpdateCallback | null>(null);
+
+// Create provider component with typed props
+export function CancelSourceUpdateProvider({
+  children,
+  onCancelSourceUpdate,
+}: ICancelSourceUpdateProviderProps): JSX.Element {
+  return (
+    <CancelSourceUpdateContext.Provider value={onCancelSourceUpdate}>
+      {children}
+    </CancelSourceUpdateContext.Provider>
+  );
+}
+
+// Export the context as a named export
+export { CancelSourceUpdateContext };
+
+// Also export as default for convenience
+export default CancelSourceUpdateContext;

--- a/src/generated/test_case.ts
+++ b/src/generated/test_case.ts
@@ -151,7 +151,6 @@ export type DownMessage =
 | { kind: 'Update'; value: ParseResults }
 | { kind: 'TestRunResults'; value: TestRunResults }
 | { kind: 'FileSelectedForNewTest'; value: FileSelection }
-| { kind: 'StandBy' }
 
 export function writeTyp(x: Typ, context: any = x): any {
   switch (x.kind) {
@@ -662,34 +661,21 @@ export function writeDownMessage(x: DownMessage, context: any = x): any {
       return ['TestRunResults', writeTestRunResults(x.value, x)]
     case 'FileSelectedForNewTest':
       return ['FileSelectedForNewTest', writeFileSelection(x.value, x)]
-    case 'StandBy':
-      return 'StandBy'
   }
 }
 
 export function readDownMessage(x: any, context: any = x): DownMessage {
-  if (typeof x === 'string') {
-    switch (x) {
-      case 'StandBy':
-        return { kind: 'StandBy' }
-      default:
-        _atd_bad_json('DownMessage', x, context)
-        throw new Error('impossible')
-    }
-  }
-  else {
-    _atd_check_json_tuple(2, x, context)
-    switch (x[0]) {
-      case 'Update':
-        return { kind: 'Update', value: readParseResults(x[1], x) }
-      case 'TestRunResults':
-        return { kind: 'TestRunResults', value: readTestRunResults(x[1], x) }
-      case 'FileSelectedForNewTest':
-        return { kind: 'FileSelectedForNewTest', value: readFileSelection(x[1], x) }
-      default:
-        _atd_bad_json('DownMessage', x, context)
-        throw new Error('impossible')
-    }
+  _atd_check_json_tuple(2, x, context)
+  switch (x[0]) {
+    case 'Update':
+      return { kind: 'Update', value: readParseResults(x[1], x) }
+    case 'TestRunResults':
+      return { kind: 'TestRunResults', value: readTestRunResults(x[1], x) }
+    case 'FileSelectedForNewTest':
+      return { kind: 'FileSelectedForNewTest', value: readFileSelection(x[1], x) }
+    default:
+      _atd_bad_json('DownMessage', x, context)
+      throw new Error('impossible')
   }
 }
 

--- a/src/generated/test_case.ts
+++ b/src/generated/test_case.ts
@@ -146,6 +146,7 @@ export type UpMessage =
 | { kind: 'TestRunRequest'; value: TestRunRequest }
 | { kind: 'TestGenerateRequest'; value: TestGenerateRequest }
 | { kind: 'SelectFileForNewTest' }
+| { kind: 'CancelSourceUpdate' }
 
 export type DownMessage =
 | { kind: 'Update'; value: ParseResults }
@@ -620,6 +621,8 @@ export function writeUpMessage(x: UpMessage, context: any = x): any {
       return ['TestGenerateRequest', writeTestGenerateRequest(x.value, x)]
     case 'SelectFileForNewTest':
       return 'SelectFileForNewTest'
+    case 'CancelSourceUpdate':
+      return 'CancelSourceUpdate'
   }
 }
 
@@ -632,6 +635,8 @@ export function readUpMessage(x: any, context: any = x): UpMessage {
         return { kind: 'OpenInTextEditor' }
       case 'SelectFileForNewTest':
         return { kind: 'SelectFileForNewTest' }
+      case 'CancelSourceUpdate':
+        return { kind: 'CancelSourceUpdate' }
       default:
         _atd_bad_json('UpMessage', x, context)
         throw new Error('impossible')

--- a/src/generated/test_case.ts
+++ b/src/generated/test_case.ts
@@ -152,6 +152,7 @@ export type DownMessage =
 | { kind: 'Update'; value: ParseResults }
 | { kind: 'TestRunResults'; value: TestRunResults }
 | { kind: 'FileSelectedForNewTest'; value: FileSelection }
+| { kind: 'DisableUI' }
 
 export function writeTyp(x: Typ, context: any = x): any {
   switch (x.kind) {
@@ -666,21 +667,34 @@ export function writeDownMessage(x: DownMessage, context: any = x): any {
       return ['TestRunResults', writeTestRunResults(x.value, x)]
     case 'FileSelectedForNewTest':
       return ['FileSelectedForNewTest', writeFileSelection(x.value, x)]
+    case 'DisableUI':
+      return 'DisableUI'
   }
 }
 
 export function readDownMessage(x: any, context: any = x): DownMessage {
-  _atd_check_json_tuple(2, x, context)
-  switch (x[0]) {
-    case 'Update':
-      return { kind: 'Update', value: readParseResults(x[1], x) }
-    case 'TestRunResults':
-      return { kind: 'TestRunResults', value: readTestRunResults(x[1], x) }
-    case 'FileSelectedForNewTest':
-      return { kind: 'FileSelectedForNewTest', value: readFileSelection(x[1], x) }
-    default:
-      _atd_bad_json('DownMessage', x, context)
-      throw new Error('impossible')
+  if (typeof x === 'string') {
+    switch (x) {
+      case 'DisableUI':
+        return { kind: 'DisableUI' }
+      default:
+        _atd_bad_json('DownMessage', x, context)
+        throw new Error('impossible')
+    }
+  }
+  else {
+    _atd_check_json_tuple(2, x, context)
+    switch (x[0]) {
+      case 'Update':
+        return { kind: 'Update', value: readParseResults(x[1], x) }
+      case 'TestRunResults':
+        return { kind: 'TestRunResults', value: readTestRunResults(x[1], x) }
+      case 'FileSelectedForNewTest':
+        return { kind: 'FileSelectedForNewTest', value: readFileSelection(x[1], x) }
+      default:
+        _atd_bad_json('DownMessage', x, context)
+        throw new Error('impossible')
+    }
   }
 }
 

--- a/src/generated/test_case.ts
+++ b/src/generated/test_case.ts
@@ -151,6 +151,7 @@ export type DownMessage =
 | { kind: 'Update'; value: ParseResults }
 | { kind: 'TestRunResults'; value: TestRunResults }
 | { kind: 'FileSelectedForNewTest'; value: FileSelection }
+| { kind: 'StandBy' }
 
 export function writeTyp(x: Typ, context: any = x): any {
   switch (x.kind) {
@@ -661,21 +662,34 @@ export function writeDownMessage(x: DownMessage, context: any = x): any {
       return ['TestRunResults', writeTestRunResults(x.value, x)]
     case 'FileSelectedForNewTest':
       return ['FileSelectedForNewTest', writeFileSelection(x.value, x)]
+    case 'StandBy':
+      return 'StandBy'
   }
 }
 
 export function readDownMessage(x: any, context: any = x): DownMessage {
-  _atd_check_json_tuple(2, x, context)
-  switch (x[0]) {
-    case 'Update':
-      return { kind: 'Update', value: readParseResults(x[1], x) }
-    case 'TestRunResults':
-      return { kind: 'TestRunResults', value: readTestRunResults(x[1], x) }
-    case 'FileSelectedForNewTest':
-      return { kind: 'FileSelectedForNewTest', value: readFileSelection(x[1], x) }
-    default:
-      _atd_bad_json('DownMessage', x, context)
-      throw new Error('impossible')
+  if (typeof x === 'string') {
+    switch (x) {
+      case 'StandBy':
+        return { kind: 'StandBy' }
+      default:
+        _atd_bad_json('DownMessage', x, context)
+        throw new Error('impossible')
+    }
+  }
+  else {
+    _atd_check_json_tuple(2, x, context)
+    switch (x[0]) {
+      case 'Update':
+        return { kind: 'Update', value: readParseResults(x[1], x) }
+      case 'TestRunResults':
+        return { kind: 'TestRunResults', value: readTestRunResults(x[1], x) }
+      case 'FileSelectedForNewTest':
+        return { kind: 'FileSelectedForNewTest', value: readFileSelection(x[1], x) }
+      default:
+        _atd_bad_json('DownMessage', x, context)
+        throw new Error('impossible')
+    }
   }
 }
 

--- a/src/generated/test_case.ts
+++ b/src/generated/test_case.ts
@@ -152,7 +152,6 @@ export type DownMessage =
 | { kind: 'Update'; value: ParseResults }
 | { kind: 'TestRunResults'; value: TestRunResults }
 | { kind: 'FileSelectedForNewTest'; value: FileSelection }
-| { kind: 'DisableUI' }
 
 export function writeTyp(x: Typ, context: any = x): any {
   switch (x.kind) {
@@ -667,34 +666,21 @@ export function writeDownMessage(x: DownMessage, context: any = x): any {
       return ['TestRunResults', writeTestRunResults(x.value, x)]
     case 'FileSelectedForNewTest':
       return ['FileSelectedForNewTest', writeFileSelection(x.value, x)]
-    case 'DisableUI':
-      return 'DisableUI'
   }
 }
 
 export function readDownMessage(x: any, context: any = x): DownMessage {
-  if (typeof x === 'string') {
-    switch (x) {
-      case 'DisableUI':
-        return { kind: 'DisableUI' }
-      default:
-        _atd_bad_json('DownMessage', x, context)
-        throw new Error('impossible')
-    }
-  }
-  else {
-    _atd_check_json_tuple(2, x, context)
-    switch (x[0]) {
-      case 'Update':
-        return { kind: 'Update', value: readParseResults(x[1], x) }
-      case 'TestRunResults':
-        return { kind: 'TestRunResults', value: readTestRunResults(x[1], x) }
-      case 'FileSelectedForNewTest':
-        return { kind: 'FileSelectedForNewTest', value: readFileSelection(x[1], x) }
-      default:
-        _atd_bad_json('DownMessage', x, context)
-        throw new Error('impossible')
-    }
+  _atd_check_json_tuple(2, x, context)
+  switch (x[0]) {
+    case 'Update':
+      return { kind: 'Update', value: readParseResults(x[1], x) }
+    case 'TestRunResults':
+      return { kind: 'TestRunResults', value: readTestRunResults(x[1], x) }
+    case 'FileSelectedForNewTest':
+      return { kind: 'FileSelectedForNewTest', value: readFileSelection(x[1], x) }
+    default:
+      _atd_bad_json('DownMessage', x, context)
+      throw new Error('impossible')
   }
 }
 

--- a/src/hooks/useCancelSourceUpdate.ts
+++ b/src/hooks/useCancelSourceUpdate.ts
@@ -1,0 +1,25 @@
+import { useContext } from 'react';
+import {
+  CancelSourceUpdateContext,
+  type CancelSourceUpdateCallback,
+} from '../contexts/CancelSourceUpdateContext';
+
+/**
+ * Custom hook for consuming the cancel source update context
+ * @returns A function to cancel source updates
+ * @throws Error when used outside of CancelSourceUpdateProvider
+ */
+export function useCancelSourceUpdate(): CancelSourceUpdateCallback {
+  const context = useContext(CancelSourceUpdateContext);
+
+  if (context === null) {
+    throw new Error(
+      'useCancelSourceUpdate must be used within a CancelSourceUpdateProvider'
+    );
+  }
+
+  return context;
+}
+
+// Export as default for convenience
+export default useCancelSourceUpdate;

--- a/src/testCaseEditor.ts
+++ b/src/testCaseEditor.ts
@@ -122,11 +122,8 @@ export class TestCaseEditorProvider implements vscode.CustomTextEditorProvider {
 
         await vscode.workspace.applyEdit(edit);
 
-        // Update the UI with the new state
-        postMessageToWebView({
-          kind: 'Update',
-          value: parseTestFile(document.getText(), lang, document.uri.fsPath),
-        });
+        // here, we do not need to update the UI explicitly
+        // because editing the text will trigger a parse loop
 
         // Reset the latest message
         latestGuiEditMessage = null;
@@ -227,27 +224,13 @@ export class TestCaseEditorProvider implements vscode.CustomTextEditorProvider {
               const updatedTests = [...currentTests.value, newTest[0]];
               const newTextBuffer = atdToCatala(updatedTests, lang);
 
-              // Disable UI before applying edits
-              postMessageToWebView({
-                kind: 'DisableUI',
-              });
-
               const edit = new vscode.WorkspaceEdit();
               edit.replace(
                 document.uri,
                 new vscode.Range(0, 0, document.lineCount, 0),
                 newTextBuffer
               );
-              vscode.workspace.applyEdit(edit).then(() => {
-                postMessageToWebView({
-                  kind: 'Update',
-                  value: parseTestFile(
-                    document.getText(),
-                    lang,
-                    document.uri.fsPath
-                  ),
-                });
-              });
+              vscode.workspace.applyEdit(edit);
             }
           } else {
             vscode.window.showErrorMessage(

--- a/src/testCaseEditor.ts
+++ b/src/testCaseEditor.ts
@@ -104,11 +104,6 @@ export class TestCaseEditorProvider implements vscode.CustomTextEditorProvider {
       isApplyingEdit = true;
 
       try {
-        // Send StandBy message to disable UI
-        postMessageToWebView({
-          kind: 'StandBy',
-        });
-
         // re-emit catala text file from ATD test definitions
         const newTextBuffer = atdToCatala(latestGuiEditMessage.value, lang);
 

--- a/src/testCaseEditor.ts
+++ b/src/testCaseEditor.ts
@@ -88,13 +88,14 @@ export class TestCaseEditorProvider implements vscode.CustomTextEditorProvider {
       });
     }
 
+    const QUIESCENCE_DELAY_MS = 1500;
+
     // Debounce mechanism for GuiEdit messages
     let guiEditTimeout: NodeJS.Timeout | null = null;
     let latestGuiEditMessage: Extract<UpMessage, { kind: 'GuiEdit' }> | null =
       null;
     let isApplyingEdit = false;
 
-    // Function to apply the edit with the latest message
     async function applyLatestEdit(lang: string): Promise<void> {
       if (!latestGuiEditMessage || isApplyingEdit) {
         return;
@@ -146,10 +147,10 @@ export class TestCaseEditorProvider implements vscode.CustomTextEditorProvider {
         clearTimeout(guiEditTimeout);
       }
 
-      // Set a new timeout for the quiescence period (1.5 seconds)
+      // Set a new timeout for the quiescence period
       guiEditTimeout = setTimeout(() => {
         applyLatestEdit(lang);
-      }, 1500);
+      }, QUIESCENCE_DELAY_MS);
     }
 
     // Hook into the save event to immediately apply edits

--- a/src/testCaseEditor.ts
+++ b/src/testCaseEditor.ts
@@ -88,7 +88,7 @@ export class TestCaseEditorProvider implements vscode.CustomTextEditorProvider {
       });
     }
 
-    const QUIESCENCE_DELAY_MS = 1500;
+    const QUIESCENCE_DELAY_MS = 1800;
 
     // Debounce mechanism for GuiEdit messages
     let guiEditTimeout: NodeJS.Timeout | null = null;

--- a/src/testCaseEditor.ts
+++ b/src/testCaseEditor.ts
@@ -94,7 +94,6 @@ export class TestCaseEditorProvider implements vscode.CustomTextEditorProvider {
     ): void {
       // re-emit catala text file from ATD test definitions
       const newTextBuffer = atdToCatala(typed_msg.value, lang);
-      logger.log(`newTextBuffer:\n ${newTextBuffer}`);
       // produce edit
       const edit = new vscode.WorkspaceEdit();
       edit.replace(

--- a/src/testCaseEditor.ts
+++ b/src/testCaseEditor.ts
@@ -88,24 +88,6 @@ export class TestCaseEditorProvider implements vscode.CustomTextEditorProvider {
       });
     }
 
-    function debounce<T extends (...args: any[]) => any>(
-      func: T,
-      waitMs: number
-    ): (...args: Parameters<T>) => void {
-      let timeoutId: ReturnType<typeof setTimeout> | null = null;
-
-      return function (...args: Parameters<T>): void {
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-        }
-
-        timeoutId = setTimeout(() => {
-          func(...args);
-          timeoutId = null;
-        }, waitMs);
-      };
-    }
-
     function applyGuiEdit(
       typed_msg: Extract<UpMessage, { kind: 'GuiEdit' }>,
       lang: string
@@ -129,8 +111,6 @@ export class TestCaseEditorProvider implements vscode.CustomTextEditorProvider {
       });
     }
 
-    const debouncedApplyGuiEdit = debounce(applyGuiEdit, 450);
-
     webviewPanel.webview.onDidReceiveMessage(async (message: unknown) => {
       const typed_msg = readUpMessage(message);
       const lang = getLanguageFromFileName(document.fileName);
@@ -152,7 +132,7 @@ export class TestCaseEditorProvider implements vscode.CustomTextEditorProvider {
         }
         case 'GuiEdit': {
           logger.log('Got edit from webview');
-          debouncedApplyGuiEdit(typed_msg, lang);
+          applyGuiEdit(typed_msg, lang);
           break;
         }
         case 'TestRunRequest': {

--- a/src/testCaseEditor.ts
+++ b/src/testCaseEditor.ts
@@ -104,6 +104,11 @@ export class TestCaseEditorProvider implements vscode.CustomTextEditorProvider {
       isApplyingEdit = true;
 
       try {
+        // Disable UI before applying edits
+        postMessageToWebView({
+          kind: 'DisableUI',
+        });
+
         // re-emit catala text file from ATD test definitions
         const newTextBuffer = atdToCatala(latestGuiEditMessage.value, lang);
 
@@ -221,6 +226,12 @@ export class TestCaseEditorProvider implements vscode.CustomTextEditorProvider {
               newTest[0] = renameIfNeeded(currentTests.value, newTest[0]); //XXX kludge?
               const updatedTests = [...currentTests.value, newTest[0]];
               const newTextBuffer = atdToCatala(updatedTests, lang);
+
+              // Disable UI before applying edits
+              postMessageToWebView({
+                kind: 'DisableUI',
+              });
+
               const edit = new vscode.WorkspaceEdit();
               edit.replace(
                 document.uri,

--- a/src/testCaseEditor.ts
+++ b/src/testCaseEditor.ts
@@ -104,11 +104,6 @@ export class TestCaseEditorProvider implements vscode.CustomTextEditorProvider {
       isApplyingEdit = true;
 
       try {
-        // Disable UI before applying edits
-        postMessageToWebView({
-          kind: 'DisableUI',
-        });
-
         // re-emit catala text file from ATD test definitions
         const newTextBuffer = atdToCatala(latestGuiEditMessage.value, lang);
 
@@ -300,6 +295,7 @@ export class TestCaseEditorProvider implements vscode.CustomTextEditorProvider {
       }
     }
 
+    const CHANGE_SUBSCRIPTION_TIMEOUT = 500;
     const changeDocumentSubscription = vscode.workspace.onDidChangeTextDocument(
       (e) => {
         if (e.document.uri.toString() === document.uri.toString()) {
@@ -311,10 +307,10 @@ export class TestCaseEditorProvider implements vscode.CustomTextEditorProvider {
             clearTimeout(textChangeTimeout);
           }
 
-          // Set a new timeout for the quiescence period (1 second)
+          // Set a new timeout for the quiescence period
           textChangeTimeout = setTimeout(() => {
             processLatestTextChange(e.document);
-          }, 1000);
+          }, CHANGE_SUBSCRIPTION_TIMEOUT);
         }
       }
     );

--- a/src/testCaseEditor.ts
+++ b/src/testCaseEditor.ts
@@ -192,6 +192,15 @@ export class TestCaseEditorProvider implements vscode.CustomTextEditorProvider {
           applyGuiEdit(typed_msg, lang);
           break;
         }
+        case 'CancelSourceUpdate': {
+          logger.log('Source update cancelled');
+          if (guiEditTimeout) {
+            clearTimeout(guiEditTimeout);
+            guiEditTimeout = null;
+          }
+
+          break;
+        }
         case 'TestRunRequest': {
           const { scope } = typed_msg.value;
           this.testQueue.add(() => runTest(document.fileName, scope));

--- a/test-case-parser/test_case.atd
+++ b/test-case-parser/test_case.atd
@@ -151,4 +151,5 @@ type down_message = [
   | Update of parse_results
   | TestRunResults of test_run_results
   | FileSelectedForNewTest of file_selection
+  | DisableUI
 ]

--- a/test-case-parser/test_case.atd
+++ b/test-case-parser/test_case.atd
@@ -144,6 +144,7 @@ type up_message = [
   | TestRunRequest of test_run_request
   | TestGenerateRequest of test_generate_request
   | SelectFileForNewTest
+  | CancelSourceUpdate
 ]
 
 type down_message = [

--- a/test-case-parser/test_case.atd
+++ b/test-case-parser/test_case.atd
@@ -150,5 +150,4 @@ type down_message = [
   | Update of parse_results
   | TestRunResults of test_run_results
   | FileSelectedForNewTest of file_selection
-  | StandBy
 ]

--- a/test-case-parser/test_case.atd
+++ b/test-case-parser/test_case.atd
@@ -150,4 +150,5 @@ type down_message = [
   | Update of parse_results
   | TestRunResults of test_run_results
   | FileSelectedForNewTest of file_selection
+  | StandBy
 ]

--- a/test-case-parser/test_case.atd
+++ b/test-case-parser/test_case.atd
@@ -151,5 +151,4 @@ type down_message = [
   | Update of parse_results
   | TestRunResults of test_run_results
   | FileSelectedForNewTest of file_selection
-  | DisableUI
 ]


### PR DESCRIPTION
This PR changes the edit behavior to decouple the UI loop from the compiler loop.

In summary

- In the react UI, whenever the user changes something, we optimistically update the data model (which is close to the catala AST) ; this keeps the UI responsive and mostly lag-free.
- We trigger updates for any valid change and optimistically accept those in the UI (which implicitly batches changes)
- We update the catala source code either
    * after 1.5s of quiescence (no GuiUpdate message received), or
    * whenever the user hits the save command
This should make the editing experience much better and remove a few glitches, performance issues and non-obvious behaviors (e.g. the test description does not only update on blur anymore) 