### PR TITLE
Remove requirement for meta-modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,16 @@
           "type": "string",
           "default": null,
           "description": "Custom path to the `catala-format` executable"
+        },
+        "catala-lsp.trace.server": {
+          "description": "Controls the logging output of the language server. Valid settings are `off`, `messages`, or `verbose`.",
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "messages"
         }
       }
     },

--- a/server/src/diagnostic.ml
+++ b/server/src/diagnostic.ml
@@ -23,12 +23,25 @@ let warn_r range message =
   Lsp.Types.Diagnostic.create ~range ~severity:Warning ~source:"catala-lsp"
     ~message ()
 
-let error_r range message =
-  Lsp.Types.Diagnostic.create ~range ~severity:Error ~source:"catala-lsp"
-    ~message ()
+let error_r ?related range message =
+  let relatedInformation =
+    Option.map
+      (List.map (fun (location, message) ->
+           DiagnosticRelatedInformation.create ~location ~message))
+      related
+  in
+  Lsp.Types.Diagnostic.create ?relatedInformation ~range ~severity:Error
+    ~source:"catala-lsp" ~message ()
 
 let warn_p pos msg = warn_r (range_of_pos pos) msg
-let error_p pos msg = error_r (range_of_pos pos) msg
+
+let error_p ?related pos msg =
+  let related =
+    Option.map
+      (List.map (fun (p, message) -> location_of_pos p, message))
+      related
+  in
+  error_r ?related (range_of_pos pos) msg
 
 let diag_r (severity : DiagnosticSeverity.t) range msg =
   match severity with

--- a/server/src/discovery.ml
+++ b/server/src/discovery.ml
@@ -1,0 +1,262 @@
+(* This file is part of the Catala compiler, a specification language for tax
+   and social benefits computation rules. Copyright (C) 2025 Inria, contributor:
+   Vincent Botbol <vincent.botbol@inria.fr>
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License. *)
+
+open Catala_utils
+
+module Scan_item = struct
+  type t = Clerk_scan.item
+
+  let compare
+      { Clerk_scan.file_name; _ }
+      { Clerk_scan.file_name = file_name'; _ } =
+    String.compare file_name file_name'
+
+  let format fmt { Clerk_scan.file_name; _ } =
+    Format.pp_print_string fmt file_name
+end
+
+module Scan_map = Map.Make (String)
+module Module_map = Map.Make (String)
+module Project_files = Set.Make (Scan_item)
+
+type project_file = {
+  file : Clerk_scan.item;
+  including_files : Project_files.t;
+  used_by : Project_files.t;
+}
+
+type project = {
+  clerk_root_dir : string;
+  clerk_config : Clerk_config.t;
+  project_files : project_file Scan_map.t;
+}
+
+type projects = (string * project) list
+
+let default =
+  {
+    clerk_root_dir = "";
+    clerk_config = Clerk_config.default_config;
+    project_files = Scan_map.empty;
+  }
+
+module S = Set.Make (String)
+
+let clean_item ({ Clerk_scan.file_name; included_files; _ } as item) =
+  {
+    item with
+    file_name = File.clean_path file_name;
+    included_files = List.map (Mark.map File.clean_path) included_files;
+  }
+
+let find_module_candidate
+    ~(notify_back : Linol_lwt.Jsonrpc2.notify_back)
+    includes
+    (file : Scan_item.t)
+    (possible_modules : Scan_item.t list)
+    (used_module : string Mark.pos) : Scan_item.t option =
+  let file_dir = File.dirname file.file_name in
+  let includes = file_dir :: includes in
+  let possible_modules =
+    List.filter
+      (fun m -> List.mem (File.dirname m.Clerk_scan.file_name) includes)
+      possible_modules
+  in
+  match possible_modules with
+  | [] -> None
+  | [modul] -> Some modul
+  | l -> (
+    match
+      List.find_opt (fun m -> file_dir = File.dirname m.Clerk_scan.file_name) l
+    with
+    | Some x -> Some x
+    | None ->
+      (* Multiple candidates possible: warn about it *)
+      let mod_def, mod_use_pos = used_module in
+      let msg = Format.sprintf "Module %s defined multiple times" mod_def in
+      let related =
+        List.filter_map
+          (fun modul ->
+            Option.map
+              (fun mod_def -> Mark.get mod_def, "Conflicting definition")
+              modul.Clerk_scan.module_def)
+          l
+      in
+      (Lwt.async
+      @@ fun () ->
+      let open Lwt.Syntax in
+      let* () = Lwt_unix.sleep 5. in
+      let diag = Diagnostic.error_p ~related mod_use_pos (`String msg) in
+      notify_back#set_uri
+        (Linol_lwt.DocumentUri.of_path file.Clerk_scan.file_name);
+      notify_back#send_diagnostic [diag]);
+      None)
+
+let retrieve_project_files
+    ~notify_back
+    (clerk_config : Clerk_config.t)
+    clerk_root_dir =
+  let open Clerk_scan in
+  Log.info (fun m -> m "building inclusion graph");
+  let tree = tree clerk_root_dir in
+  let known_items = Hashtbl.create 10 in
+  let known_modules = Hashtbl.create 10 in
+  Seq.iter
+    (fun (_, _, items) ->
+      List.iter
+        (fun item ->
+          let item = clean_item item in
+          Hashtbl.add known_items item.file_name item;
+          Option.iter
+            (fun module_def ->
+              let module_def = Mark.remove module_def in
+              (* Module with the same name may be declared multiple times *)
+              match Hashtbl.find_opt known_modules module_def with
+              | None -> Hashtbl.add known_modules module_def [item]
+              | Some l -> Hashtbl.replace known_modules module_def (item :: l))
+            item.module_def)
+        items)
+    tree;
+  let g =
+    Hashtbl.fold
+      (fun _n item g ->
+        Scan_map.add item.file_name
+          {
+            file = item;
+            including_files = Project_files.empty;
+            used_by = Project_files.empty;
+          }
+          g)
+      known_items Scan_map.empty
+  in
+  Hashtbl.fold
+    (fun n item g ->
+      let included_items =
+        List.filter_map
+          (fun includ ->
+            Hashtbl.find_opt known_items (Mark.remove includ)
+            |> function
+            | Some x -> Some x
+            | None ->
+              Log.warn (fun m ->
+                  m "Did not find included file '%s' declared in '%s'"
+                    (Mark.remove includ) n);
+              None)
+          item.included_files
+      in
+      (* Update including files *)
+      let g =
+        List.fold_left
+          (fun g included_item ->
+            Scan_map.update included_item.file_name
+              (function
+                | None ->
+                  Some
+                    {
+                      file = included_item;
+                      including_files = Project_files.singleton item;
+                      used_by = Project_files.empty;
+                    }
+                | Some pf ->
+                  Some
+                    {
+                      pf with
+                      including_files =
+                        Project_files.add item pf.including_files;
+                    })
+              g)
+          g included_items
+      in
+      (* Update used-by files *)
+      List.fold_left
+        (fun g (used_module : string Mark.pos) ->
+          let used_module_name = Mark.remove used_module in
+          let possible_modules =
+            Option.value ~default:[]
+              (Hashtbl.find_opt known_modules used_module_name)
+          in
+          find_module_candidate ~notify_back clerk_config.global.include_dirs
+            item possible_modules used_module
+          |> function
+          | None -> (* No file using this module *) g
+          | Some modul ->
+            (* Found a good module candidate *)
+            Scan_map.update item.file_name
+              (function
+                | None ->
+                  Some
+                    {
+                      file = item;
+                      including_files = Project_files.empty;
+                      used_by = Project_files.singleton modul;
+                    }
+                | Some pf ->
+                  Some { pf with used_by = Project_files.add modul pf.used_by })
+              g)
+        g item.used_modules)
+    known_items g
+
+let init ~notify_back (params : Linol_lwt.InitializeParams.t) : projects option
+    =
+  let open Monad.Option in
+  Log.debug (fun m -> m "initializing project");
+  let no_workspace_folder_provided () =
+    Log.warn (fun m -> m "no workspace folder provided")
+  in
+  let*?! workspaceFolders =
+    params.workspaceFolders, no_workspace_folder_provided
+  in
+  let*?! workspaceFolders = workspaceFolders, no_workspace_folder_provided in
+  if workspaceFolders = [] then (
+    no_workspace_folder_provided ();
+    None)
+  else
+    List.filter_map
+      (fun workspaceFolder ->
+        let workspace_path =
+          Uri.pct_decode
+            (Linol_lwt.DocumentUri.to_path
+               workspaceFolder.Linol_lwt.WorkspaceFolder.uri)
+        in
+        match Utils.lookup_clerk_toml workspace_path with
+        | None ->
+          Log.warn (fun m ->
+              m
+                "no clerk config file found, assuming project directory as \
+                 root directory");
+          let clerk_config = Clerk_config.default_config in
+          let clerk_root_dir = workspace_path in
+          let project_files =
+            retrieve_project_files ~notify_back clerk_config clerk_root_dir
+          in
+          ok (workspace_path, { clerk_root_dir; clerk_config; project_files })
+        | Some (clerk_config, clerk_root_dir) ->
+          Log.debug (fun m ->
+              m "clerk file found in '%s' directory" clerk_root_dir);
+          let project_files =
+            retrieve_project_files ~notify_back clerk_config clerk_root_dir
+          in
+          ok (workspace_path, { clerk_root_dir; clerk_config; project_files }))
+      workspaceFolders
+    |> function
+    | [] ->
+      no_workspace_folder_provided ();
+      None
+    | l ->
+      List.iter
+        (fun (project, _) -> Log.app (fun m -> m "project %s loaded" project))
+        l;
+      Some l

--- a/server/src/dune
+++ b/server/src/dune
@@ -19,12 +19,12 @@
   logs.fmt
   catala.driver
   catala.surface
-  catala.clerk_config
+  catala.clerk_lib
   uri
   re)
  (modules
   (:standard \ Main))
- (flags (:standard)))
+ (flags (:standard -open Clerk_lib)))
 
 (alias
  (name lsp)

--- a/server/src/monad.ml
+++ b/server/src/monad.ml
@@ -1,0 +1,34 @@
+(* This file is part of the Catala compiler, a specification language for tax
+   and social benefits computation rules. Copyright (C) 2025 Inria, contributor:
+   Vincent Botbol <vincent.botbol@inria.fr>
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License. *)
+
+module Option = struct
+  let ( let* ) = Option.bind
+  let ( let*? ) x f = match x with None -> None | Some x -> f x
+
+  let ( let*?! ) (x, log) f =
+    match x with
+    | None ->
+      log ();
+      None
+    | Some x -> f x
+
+  let nil_msg = Fun.id
+  let return = Option.some
+  let some = Option.some
+  let ok = some
+  let none = Option.none
+  let somek x = some x, nil_msg
+end

--- a/server/src/state.ml
+++ b/server/src/state.ml
@@ -508,12 +508,22 @@ let process_document ?previous_file ?contents (uri : string) : t =
       | _ ->
         let prg =
           Scopelang.From_desugared.translate_program prg exceptions_graphs
+          |> Scopelang.Ast.type_program
         in
         let _type_ordering =
           Scopelang.Dependency.check_type_cycles prg.program_ctx.ctx_structs
             prg.program_ctx.ctx_enums
         in
-        let prg = Scopelang.Ast.type_program prg in
+        let _ =
+          let type_ordering =
+            Scopelang.Dependency.check_type_cycles prg.program_ctx.ctx_structs
+              prg.program_ctx.ctx_enums
+          in
+          let prg = Scopelang.Ast.type_program prg in
+          let prg = Dcalc.From_scopelang.translate_program prg in
+          let prg = Shared_ast.Typing.program ~internal_check:true prg in
+          prg, type_ordering
+        in
         let jump_table =
           Jump.populate input_src ctx modules_contents surface prg
         in

--- a/server/src/state.ml
+++ b/server/src/state.ml
@@ -229,53 +229,6 @@ let lookup_document_symbols file =
           vl acc)
       variables []
 
-let lookup_clerk_toml (path : string) =
-  let from_dir = Filename.dirname path in
-  let open Catala_utils in
-  let find_in_parents cwd predicate =
-    let home = try Sys.getenv "HOME" with Not_found -> "" in
-    let rec lookup dir =
-      if predicate dir then Some dir
-      else if dir = home then None
-      else
-        let parent = Filename.dirname dir in
-        if parent = dir then None else lookup parent
-    in
-    match lookup cwd with Some rel -> Some rel | None -> None
-  in
-  try
-    begin
-      match
-        find_in_parents from_dir (fun dir -> File.(exists (dir / "clerk.toml")))
-      with
-      | None ->
-        Log.debug (fun m -> m "no 'clerk.toml' config file found");
-        None
-      | Some dir -> (
-        Log.debug (fun m ->
-            m "found config file at: '%s'" (Filename.concat dir "clerk.toml"));
-        try
-          let config = Clerk_config.read File.(dir / "clerk.toml") in
-          let include_dirs =
-            let cwd = Sys.getcwd () in
-            List.map
-              (fun p -> Utils.join_paths cwd p)
-              config.global.include_dirs
-          in
-          let config =
-            { config with global = { config.global with include_dirs } }
-          in
-          Some (config, dir)
-        with Message.CompilerError c ->
-          Log.err (fun m ->
-              let pp fmt = Message.Content.emit ~ppf:fmt c Error in
-              m "error while parsing config file: %t" pp);
-          None)
-    end
-  with _ ->
-    Log.err (fun m -> m "failed to lookup config file");
-    None
-
 let load_module_interfaces config_dir includes program =
   (* Recurse into program modules, looking up files in [using] and loading
      them *)
@@ -376,71 +329,11 @@ let load_module_interfaces config_dir includes program =
   in
   root_uses, modules
 
-let find_inclusion (config_opt : (Clerk_config.t * string) option) file =
-  let open Catala_utils in
-  match config_opt with
-  | None -> None
-  | Some (config, config_dir) ->
-    List.fold_left
-      (fun acc ({ Clerk_config.name = mod_name; includes; _ } as modul) ->
-        if acc <> None then acc
-        else
-          let is_present =
-            List.exists
-              (fun included_file ->
-                File.equal (Filename.concat config_dir included_file) file)
-              includes
-          in
-          if is_present then Some (mod_name, modul) else None)
-      None config.modules
-
-let convert_meta_module
-    ~config_dir
-    (meta_module_name, (modul : Clerk_config.module_)) :
-    string Catala_utils.Global.input_src =
-  let language =
-    (* The language is the same as the included files or module used. *)
-    List.fold_left
-      (function
-        | None -> (
-          fun f -> try Some (Catala_utils.Cli.file_lang f) with _ -> None)
-        | acc -> fun _ -> acc)
-      None
-      (modul.includes
-      @ List.map
-          (function `Simple s | `With_alias (s, _) -> s)
-          modul.module_uses)
-    |> Option.value ~default:Catala_utils.Global.En
-  in
-  let pp_module
-      ppf
-      { Clerk_config.name = _; module_uses; includes : string list } =
-    let open Format in
-    let use_kwd, alias_kwd, include_kwd, module_kwd =
-      match language with
-      | Pl | En -> "Using", "as", "Include:", "Module"
-      | Fr -> "Usage de", "en tant que", "Inclusion:", "Module"
-    in
-    let pp_use ppf = function
-      | `Simple mod_name -> fprintf ppf "> %s %s" use_kwd mod_name
-      | `With_alias (mod_name, alias) ->
-        fprintf ppf "> %s %s %s %s" use_kwd mod_name alias_kwd alias
-    in
-    let pp_include ppf mod_path = fprintf ppf "> %s %s" include_kwd mod_path in
-    fprintf ppf "@[<v>@[<v>%a@]@ > %s %s@ @[<v>%a@]@]"
-      (pp_print_list ~pp_sep:pp_print_cut pp_use)
-      module_uses module_kwd meta_module_name
-      (pp_print_list ~pp_sep:pp_print_cut pp_include)
-      includes
-  in
-  Log.info (fun m -> m "generated meta-module:@\n%a@." pp_module modul);
-  Catala_utils.Global.Contents
-    ( Format.asprintf "%a" pp_module modul,
-      Filename.concat config_dir
-        (meta_module_name ^ ".catala_" ^ Catala_utils.Cli.language_code language)
-    )
-
-let process_document ?previous_file ?contents (uri : string) : t =
+let process_document
+    ?previous_file
+    ?contents
+    (project_state : Discovery.project)
+    (uri : string) : t =
   let open Catala_utils in
   Log.info (fun m -> m "processing document '%s'" uri);
   let uri = Uri.pct_decode uri in
@@ -449,17 +342,32 @@ let process_document ?previous_file ?contents (uri : string) : t =
     | None -> Global.FileName uri
     | Some c -> Contents (c, uri)
   in
-  let config_opt = lookup_clerk_toml uri in
   let input_src, resolve_included_file =
-    match config_opt, find_inclusion config_opt uri with
-    | Some (_, config_dir), Some i ->
-      Log.info (fun m ->
-          m "found document included as part of a meta-module: generating it.");
-      let resolve_included_file path =
-        if File.equal path uri then input_src else Global.FileName path
-      in
-      convert_meta_module ~config_dir i, Some resolve_included_file
-    | _ -> input_src, None
+    let project_file_opt =
+      Discovery.Scan_map.find_opt uri project_state.project_files
+    in
+    match project_file_opt with
+    | None -> (* should not happen *) input_src, None
+    | Some { Discovery.file = _; including_files; _ } ->
+      let module S = Discovery.Project_files in
+      if S.is_empty including_files then input_src, None
+      else begin
+        Log.info (fun m ->
+            m "found document included in files: %a" Utils.pp_string_list
+              (S.elements including_files
+              |> List.map (fun { Clerk_scan.file_name; _ } -> file_name)));
+        let including_file = S.choose including_files in
+        if S.cardinal including_files > 1 then
+          (* TODO: also handle multiple file processing *)
+          Log.info (fun m -> m "found multiple document inclusion");
+        Log.info (fun m ->
+            m "found document inclusion in %s - processing this one instead"
+              including_file.file_name);
+        let resolve_included_file path =
+          if File.equal path uri then input_src else Global.FileName path
+        in
+        FileName including_file.file_name, Some resolve_included_file
+      end
   in
   let _ = Catala_utils.Global.enforce_options ~input_src () in
   let l = ref [] in
@@ -473,15 +381,12 @@ let process_document ?previous_file ?contents (uri : string) : t =
         Surface.Parser_driver.parse_top_level_file ?resolve_included_file
           input_src
       in
-      let (prg as surface) = prg
-      in
+      let (prg as surface) = prg in
       let open Catala_utils in
       let ctx, modules_contents =
         let mod_uses, modules =
-          match config_opt with
-          | None -> String.Map.empty, Uid.Module.Map.empty
-          | Some (config, config_dir) ->
-            load_module_interfaces config_dir config.global.include_dirs prg
+          load_module_interfaces project_state.clerk_root_dir
+            project_state.clerk_config.global.include_dirs prg
         in
         let ctx =
           Desugared.Name_resolution.form_context (prg, mod_uses) modules
@@ -561,7 +466,6 @@ let process_document ?previous_file ?contents (uri : string) : t =
             Log.debug (fun m -> m "error (%d/%d): %t" (succ i) err_len pp_err)
           else Log.debug (fun m -> m "error: %t" pp_err))
         errors;
-
       List.rev !l, None, None
   in
   let file = create ?prog uri in

--- a/server/src/utils.ml
+++ b/server/src/utils.ml
@@ -21,6 +21,13 @@ let pp_opt pp fmt =
   let open Format in
   function None -> fprintf fmt "<none>" | Some v -> fprintf fmt "%a" pp v
 
+let pp_list pp fmt =
+  let open Format in
+  fprintf fmt "[@ %a@ ]"
+    (pp_print_list ~pp_sep:(fun fmt () -> fprintf fmt " ;@ ") pp)
+
+let pp_string_list fmt = pp_list Format.pp_print_string fmt
+
 let is_included (p : Pos.t) p' =
   (* true if p is included in p' *)
   Pos.get_file p = Pos.get_file p'
@@ -50,6 +57,11 @@ let pos_to_loc (pos : Pos.t) : Linol_lwt.Position.t * Linol_lwt.Position.t =
 let range_of_pos (pos : Pos.t) : Range.t =
   let start, end_ = pos_to_loc pos in
   { Range.start; end_ }
+
+let location_of_pos (pos : Pos.t) : Location.t =
+  let start, end_ = pos_to_loc pos in
+  let range = { Range.start; end_ } in
+  Location.create ~range ~uri:(DocumentUri.of_path (Pos.get_file pos))
 
 let unclosed_range_of_pos (pos : Pos.t) : Range.t =
   let start, end_ = pos_to_loc pos in
@@ -223,3 +235,49 @@ let join_paths ?(abs = true) dir path =
   loop [] (dir, path)
   |> List.rev
   |> List.fold_left ( / ) (if abs then "/" else "")
+
+let lookup_clerk_toml (path : string) =
+  let from_dir =
+    if Sys.is_directory path then path else Filename.dirname path
+  in
+  let open Catala_utils in
+  let find_in_parents cwd predicate =
+    let home = try Sys.getenv "HOME" with Not_found -> "" in
+    let rec lookup dir =
+      if predicate dir then Some dir
+      else if dir = home then None
+      else
+        let parent = Filename.dirname dir in
+        if parent = dir then None else lookup parent
+    in
+    match lookup cwd with Some rel -> Some rel | None -> None
+  in
+  try
+    begin
+      match
+        find_in_parents from_dir (fun dir -> File.(exists (dir / "clerk.toml")))
+      with
+      | None ->
+        Log.debug (fun m -> m "no 'clerk.toml' config file found");
+        None
+      | Some dir -> (
+        Log.debug (fun m ->
+            m "found config file at: '%s'" (Filename.concat dir "clerk.toml"));
+        try
+          let config = Clerk_config.read File.(dir / "clerk.toml") in
+          let include_dirs =
+            List.map (fun p -> join_paths dir p) config.global.include_dirs
+          in
+          let config =
+            { config with global = { config.global with include_dirs } }
+          in
+          Some (config, dir)
+        with Message.CompilerError c ->
+          Log.err (fun m ->
+              let pp fmt = Message.Content.emit ~ppf:fmt c Error in
+              m "error while parsing config file: %t" pp);
+          None)
+    end
+  with _ ->
+    Log.err (fun m -> m "failed to lookup config file");
+    None

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,9 @@
 import * as vscode from 'vscode';
-import type { Executable } from 'vscode-languageclient/node';
+import type {
+  Executable,
+  LanguageClientOptions,
+  ServerOptions,
+} from 'vscode-languageclient/node';
 import { LanguageClient } from 'vscode-languageclient/node';
 import * as path from 'path';
 
@@ -62,18 +66,20 @@ export function activate(context: vscode.ExtensionContext): void {
       cmd = lsp_binary;
     }
     const run: Executable = { command: cmd };
+    const serverOptions: ServerOptions = { run, debug: run };
+    const clientOptions: LanguageClientOptions = {
+      markdown: { isTrusted: true, supportHtml: true },
+      documentSelector: [
+        { scheme: 'file', language: 'catala_en', pattern: '**/*.catala_en' },
+        { scheme: 'file', language: 'catala_fr', pattern: '**/*.catala_fr' },
+      ],
+    };
     client = new LanguageClient(
-      cmd,
+      'catala-lsp',
       'Catala Language Server Protocol',
-      { run, debug: run },
-      {
-        documentSelector: [
-          { scheme: 'file', language: 'catala_en', pattern: '**/*.catala_en' },
-          { scheme: 'file', language: 'catala_fr', pattern: '**/*.catala_fr' },
-        ],
-      }
+      serverOptions,
+      clientOptions
     );
-
     client.start();
   }
 

--- a/test-case-parser/dune
+++ b/test-case-parser/dune
@@ -13,7 +13,7 @@
 (library
  (name test_case_parser_lib)
  (modules test_case_t test_case_j test_case_parser_lib)
- (libraries catala.driver catala.clerk_config atdgen-runtime))
+ (libraries catala.driver catala.clerk_lib atdgen-runtime))
 
 (executable
  (name testcase)
@@ -22,7 +22,7 @@
  (libraries yojson atdgen-runtime test_case_parser_lib)
  (embed_in_plugin_libraries
   otoml
-  catala.clerk_config
+  catala.clerk_lib
   yojson
   atdgen-runtime
   test_case_parser_lib))

--- a/test-case-parser/test_case_parser_lib.ml
+++ b/test-case-parser/test_case_parser_lib.ml
@@ -13,6 +13,7 @@
    the License. *)
 
 open Catala_utils
+open Clerk_lib
 open Shared_ast
 module I = Desugared.Ast
 module O = Test_case_t


### PR DESCRIPTION
This PR removes the need for meta-module declaration by scanning workspaces during initialization.
This scanning step attempts to discover a clerk file per workspace and analyze its hierarchy and inclusion rules so that error in included files are propagated correctly which was previously done by manual declaration (as clerk meta-modules which we aim to remove). 

This work still lacks some dynamic features that allow to maintain a consistent project hierarchy that I aim to improve as we properly define a structure for a Catala/clerk project.

Also, it displays a proper error when a module usage is ambiguous (i.e., when two modules with the same names are valid candidates)

Depends on https://github.com/CatalaLang/catala/pull/815