### PR TITLE
add devcontainer.json and supporting Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+FROM docker.io/ocaml/opam:debian-12-ocaml-5.0
+
+USER root
+
+RUN apt-get update && apt-get install -y git ca-certificates libgmp-dev pkg-config ninja-build nodejs npm openjdk-17-jdk && rm -rf /var/lib/apt/lists/*
+
+USER opam
+
+CMD ["/bin/bash"]
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "build": { "dockerfile": "Dockerfile" },
+  "postCreateCommand": "npm install && npm run compile && opam install -y .",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "catala.enableCustomTestCaseEditor": true
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Catala VSCode extension and LSP server
 
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/CatalaLang/catala-language-server?quickstart=1)
+
 ## Disclaimer
 
 Be advised that this is a work in progress repository and is not yet


### PR DESCRIPTION
Add devcontainer config and codespace badge for the catala-language-server repo.

Thanks to @guillaumeFerard for providing initial devcontainer and Dockerfile from his dev setup for inspiration

Notes

- Since it is a dev environment, initial launch will take time, because we are building/installing the vscode extension from the sources ; for other uses (experimenting, teaching) we should provide a base config with everything in the docker image (perhaps for catala-examples ?)
- It's hard to test locally :-) I made sure that the container builds and that attaching a (locally running) vs code instance to the container works but that's about it