### PR TITLE
Handle failed asserts

### DIFF
--- a/server/src/state.ml
+++ b/server/src/state.ml
@@ -42,7 +42,7 @@ type file = {
 type t = file
 
 let err_severity = function
-  | Catala_utils.Message.Lexing | Parsing | Typing | Generic ->
+  | Catala_utils.Message.Lexing | Parsing | Typing | Generic | AssertFailure ->
     DiagnosticSeverity.Error
   | Warning -> Warning
 

--- a/src/TestEditor.tsx
+++ b/src/TestEditor.tsx
@@ -77,12 +77,19 @@ export default function TestEditor(props: Props): ReactElement {
         {props.runState?.status === 'success' &&
           props.runState?.results?.kind === 'Ok' &&
           !props.runState.results.value.assert_failures && (
-            <span className="test-run-success">Passed</span>
+            <span className="test-run-success">
+              <FormattedMessage
+                id="testEditor.passed"
+                defaultMessage="Passed"
+              />
+            </span>
           )}
         {(props.runState?.status === 'error' ||
           (props.runState?.results?.kind === 'Ok' &&
             props.runState.results.value.assert_failures)) && (
-          <span className="test-run-error">Failed</span>
+          <span className="test-run-error">
+            <FormattedMessage id="testEditor.failed" defaultMessage="Failed" />
+          </span>
         )}
         <button
           className="test-editor-delete"

--- a/src/TestEditor.tsx
+++ b/src/TestEditor.tsx
@@ -74,10 +74,14 @@ export default function TestEditor(props: Props): ReactElement {
           <b>{props.test.testing_scope}</b> ➛{' '}
           {String(props.test.tested_scope.name)}
         </span>
-        {props.runState?.status === 'success' && (
-          <span className="test-run-success">Passed</span>
-        )}
-        {props.runState?.status === 'error' && (
+        {props.runState?.status === 'success' &&
+          props.runState?.results?.kind === 'Ok' &&
+          !props.runState.results.value.assert_failures && (
+            <span className="test-run-success">Passed</span>
+          )}
+        {(props.runState?.status === 'error' ||
+          (props.runState?.results?.kind === 'Ok' &&
+            props.runState.results.value.assert_failures)) && (
           <span className="test-run-error">Failed</span>
         )}
         <button
@@ -151,7 +155,7 @@ export default function TestEditor(props: Props): ReactElement {
                 <Results
                   {...select(
                     props.test.test_outputs,
-                    props.runState.results.value
+                    props.runState.results.value.test_outputs
                   )}
                 />
               </div>

--- a/src/generated/test_case.ts
+++ b/src/generated/test_case.ts
@@ -122,9 +122,14 @@ export type ParseResults =
 | { kind: 'EmptyTestListMismatch' }
 | { kind: 'Results'; value: TestList }
 
+export type TestRunOutput = {
+  test_outputs: TestOutputs;
+  assert_failures: boolean;
+}
+
 export type TestRunResults =
 | { kind: 'Error'; value: string }
-| { kind: 'Ok'; value: TestOutputs }
+| { kind: 'Ok'; value: TestRunOutput }
 
 export type TestGenerateResults =
 | { kind: 'Error'; value: string }
@@ -541,12 +546,26 @@ export function readParseResults(x: any, context: any = x): ParseResults {
   }
 }
 
+export function writeTestRunOutput(x: TestRunOutput, context: any = x): any {
+  return {
+    'test_outputs': _atd_write_required_field('TestRunOutput', 'test_outputs', writeTestOutputs, x.test_outputs, x),
+    'assert_failures': _atd_write_required_field('TestRunOutput', 'assert_failures', _atd_write_bool, x.assert_failures, x),
+  };
+}
+
+export function readTestRunOutput(x: any, context: any = x): TestRunOutput {
+  return {
+    test_outputs: _atd_read_required_field('TestRunOutput', 'test_outputs', readTestOutputs, x['test_outputs'], x),
+    assert_failures: _atd_read_required_field('TestRunOutput', 'assert_failures', _atd_read_bool, x['assert_failures'], x),
+  };
+}
+
 export function writeTestRunResults(x: TestRunResults, context: any = x): any {
   switch (x.kind) {
     case 'Error':
       return ['Error', _atd_write_string(x.value, x)]
     case 'Ok':
-      return ['Ok', writeTestOutputs(x.value, x)]
+      return ['Ok', writeTestRunOutput(x.value, x)]
   }
 }
 
@@ -556,7 +575,7 @@ export function readTestRunResults(x: any, context: any = x): TestRunResults {
     case 'Error':
       return { kind: 'Error', value: _atd_read_string(x[1], x) }
     case 'Ok':
-      return { kind: 'Ok', value: readTestOutputs(x[1], x) }
+      return { kind: 'Ok', value: readTestRunOutput(x[1], x) }
     default:
       _atd_bad_json('TestRunResults', x, context)
       throw new Error('impossible')

--- a/src/generated/test_case.ts
+++ b/src/generated/test_case.ts
@@ -108,6 +108,11 @@ export type Test = {
   description: string;
 }
 
+export type TestRun = {
+  test: Test;
+  assert_failures: boolean;
+}
+
 export type TestList = Test[]
 
 export type ScopeDefList = ScopeDef[]
@@ -468,6 +473,20 @@ export function readTest(x: any, context: any = x): Test {
     test_inputs: _atd_read_required_field('Test', 'test_inputs', readTestInputs, x['test_inputs'], x),
     test_outputs: _atd_read_required_field('Test', 'test_outputs', readTestOutputs, x['test_outputs'], x),
     description: _atd_read_required_field('Test', 'description', _atd_read_string, x['description'], x),
+  };
+}
+
+export function writeTestRun(x: TestRun, context: any = x): any {
+  return {
+    'test': _atd_write_required_field('TestRun', 'test', writeTest, x.test, x),
+    'assert_failures': _atd_write_required_field('TestRun', 'assert_failures', _atd_write_bool, x.assert_failures, x),
+  };
+}
+
+export function readTestRun(x: any, context: any = x): TestRun {
+  return {
+    test: _atd_read_required_field('TestRun', 'test', readTest, x['test'], x),
+    assert_failures: _atd_read_required_field('TestRun', 'assert_failures', _atd_read_bool, x['assert_failures'], x),
   };
 }
 

--- a/src/testCaseCompilerInterop.ts
+++ b/src/testCaseCompilerInterop.ts
@@ -115,7 +115,7 @@ export function runTestScope(
     if (cwd) {
       const relFilename = path.relative(cwd, filename);
       //compile dependencies (hack), do not fail on asserts
-      execFileSync(clerkPath, ['run', '--no-fail-on-assert', relFilename], {
+      execFileSync(clerkPath, ['run', '-c--no-fail-on-assert', relFilename], {
         cwd,
       });
     }
@@ -125,7 +125,10 @@ export function runTestScope(
     const testRun = readTestRun(JSON.parse(result.toString()));
     return {
       kind: 'Ok',
-      value: testRun.test.test_outputs,
+      value: {
+        test_outputs: testRun.test.test_outputs,
+        assert_failures: testRun.assert_failures,
+      },
     };
   } catch (error) {
     const errorMsg = String(

--- a/src/testCaseCompilerInterop.ts
+++ b/src/testCaseCompilerInterop.ts
@@ -3,8 +3,8 @@ import { execFileSync, type SpawnSyncReturns } from 'child_process';
 import type { ScopeDefList, TestGenerateResults } from './generated/test_case';
 import {
   readScopeDefList,
-  readTest,
   readTestList,
+  readTestRun,
   writeTestList,
   type ParseResults,
   type TestList,
@@ -122,10 +122,10 @@ export function runTestScope(
     // Here we *do* want to fail on asserts, as we catch failures through
     // the `register_lsp_error_notifier` hook.
     const result = execFileSync(catalaPath, args, { ...(cwd && { cwd }) });
-    const test = readTest(JSON.parse(result.toString()));
+    const testRun = readTestRun(JSON.parse(result.toString()));
     return {
       kind: 'Ok',
-      value: test.test_outputs,
+      value: testRun.test.test_outputs,
     };
   } catch (error) {
     const errorMsg = String(

--- a/src/testCaseCompilerInterop.ts
+++ b/src/testCaseCompilerInterop.ts
@@ -108,21 +108,16 @@ export function runTestScope(
    * these could be handled externally as well)
    */
 
-  const args = [
-    'testcase',
-    'run',
-    '--no-fail-on-assert',
-    '--scope',
-    testScope,
-    filename,
-  ];
+  const args = ['testcase', 'run', '--scope', testScope, filename];
   logger.log(`Exec: ${catalaPath} ${args.join(' ')}`);
   try {
-    //compile dependencies (hack), do not fail on asserts
     const cwd = getCwd(filename);
     if (cwd) {
       const relFilename = path.relative(cwd, filename);
-      execFileSync(clerkPath, ['run', relFilename], { cwd });
+      //compile dependencies (hack), do not fail on asserts
+      execFileSync(clerkPath, ['run', '--no-fail-on-assert', relFilename], {
+        cwd,
+      });
     }
     // Here we *do* want to fail on asserts, as we catch failures through
     // the `register_lsp_error_notifier` hook.

--- a/test-case-parser/test_case.atd
+++ b/test-case-parser/test_case.atd
@@ -101,6 +101,11 @@ type test = {
   description: string;
 }
 
+type test_run = {
+  test: test;
+  assert_failures: bool;
+}
+
 type test_list = test list
 
 type scope_def_list = scope_def list

--- a/test-case-parser/test_case.atd
+++ b/test-case-parser/test_case.atd
@@ -118,9 +118,14 @@ type parse_results = [
   | Results of test_list (* may be empty, that's fine as long as the buffer is empty too *)
 ]
 
+type test_run_output = {
+  test_outputs: test_outputs;
+  assert_failures: bool;
+}
+
 type test_run_results = [
   | Error of string
-  | Ok of test_outputs
+  | Ok of test_run_output
 ]
 
 type test_generate_results = [


### PR DESCRIPTION
This overhauls and fixes the behavior of test evaluation : we use the plugin ("back") of the UI to catch test assert failures and signal those to the GUI instead of filtering out assertions and punting the task to the UI.

This needs the PR https://github.com/CatalaLang/catala/pull/851 to be merged first (thanks @AltGr !) -- that PR introduces a specific kind for assertion errors and an absorber hook that we use to catch assertions before they abort the interpretation.