### PR TITLE
Check clean buffer before test run

### DIFF
--- a/src/TestEditor.tsx
+++ b/src/TestEditor.tsx
@@ -10,6 +10,7 @@ import TestInputsEditor from './TestInputsEditor';
 import TestOutputsEditor from './TestOutputsEditor';
 import Results from './Results';
 import { select } from './testCaseUtils';
+import { type TestRunStatus } from './TestFileEditor';
 
 type Props = {
   test: Test;
@@ -18,7 +19,7 @@ type Props = {
   onTestRun(testScope: string): void;
   onTestOutputsReset(testScope: string): void;
   runState?: {
-    status: 'running' | 'success' | 'error';
+    status: TestRunStatus;
     results?: TestRunResults;
   };
 };

--- a/src/TestOutputsEditor.tsx
+++ b/src/TestOutputsEditor.tsx
@@ -24,9 +24,6 @@ type Props = {
    This component aggregates all outputs (assertions)
    for a single test and offers an interface for CRUD operations
    on assertions.
-
-   We will also need a 'reset assertions to current output value'
-   which will run the test and fill assertions values with the scope output.
 */
 
 export default function TestOutputsEditor({

--- a/src/generated/test_case.ts
+++ b/src/generated/test_case.ts
@@ -130,6 +130,7 @@ export type TestRunOutput = {
 export type TestRunResults =
 | { kind: 'Error'; value: string }
 | { kind: 'Ok'; value: TestRunOutput }
+| { kind: 'Cancelled' }
 
 export type TestGenerateResults =
 | { kind: 'Error'; value: string }
@@ -567,19 +568,32 @@ export function writeTestRunResults(x: TestRunResults, context: any = x): any {
       return ['Error', _atd_write_string(x.value, x)]
     case 'Ok':
       return ['Ok', writeTestRunOutput(x.value, x)]
+    case 'Cancelled':
+      return 'Cancelled'
   }
 }
 
 export function readTestRunResults(x: any, context: any = x): TestRunResults {
-  _atd_check_json_tuple(2, x, context)
-  switch (x[0]) {
-    case 'Error':
-      return { kind: 'Error', value: _atd_read_string(x[1], x) }
-    case 'Ok':
-      return { kind: 'Ok', value: readTestRunOutput(x[1], x) }
-    default:
-      _atd_bad_json('TestRunResults', x, context)
-      throw new Error('impossible')
+  if (typeof x === 'string') {
+    switch (x) {
+      case 'Cancelled':
+        return { kind: 'Cancelled' }
+      default:
+        _atd_bad_json('TestRunResults', x, context)
+        throw new Error('impossible')
+    }
+  }
+  else {
+    _atd_check_json_tuple(2, x, context)
+    switch (x[0]) {
+      case 'Error':
+        return { kind: 'Error', value: _atd_read_string(x[1], x) }
+      case 'Ok':
+        return { kind: 'Ok', value: readTestRunOutput(x[1], x) }
+      default:
+        _atd_bad_json('TestRunResults', x, context)
+        throw new Error('impossible')
+    }
   }
 }
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -7,11 +7,25 @@ export const messages = {
     resetOutputsConfirmation:
       'Replace expected outputs with test run results. Are you sure?',
     resetButton: 'Replace',
+    unsavedChangesWarning:
+      'The file has unsaved changes. Save before running test?',
+    saveAndRun: 'Save and Run',
+    runWithoutSaving: 'Run Without Saving',
+    runAgainstSavedContent:
+      'Test will run against the saved file content, not your current changes.',
+    continue: 'Continue',
   },
   fr: {
     resetOutputsConfirmation:
       "Remplacer les sorties attendues par le résultat de l'exécution du test ?",
     resetButton: 'Remplacer',
+    unsavedChangesWarning:
+      "Le fichier contient des modifications non enregistrées. Enregistrer avant d'exécuter le test ?",
+    saveAndRun: 'Enregistrer et exécuter',
+    runWithoutSaving: 'Exécuter sans enregistrer',
+    runAgainstSavedContent:
+      "Le test s'exécutera sur la version enregistrée du fichier, pas sur vos modifications actuelles.",
+    continue: 'Continuer',
   },
 };
 

--- a/src/testCaseCompilerInterop.ts
+++ b/src/testCaseCompilerInterop.ts
@@ -95,11 +95,6 @@ export function runTestScope(
 ): TestRunResults {
   /*
    * Notes:
-   * - when parsing / generating tests, we operate on the current text buffer
-   * in the editor through `stdin`. Here, we run the actual file on disk.
-   * Should we produce an error if they are not identical? (i.e. the buffer
-   * is dirty)? -- no: a better behavior would be to prompt the user to save
-   * and to abort the test run if the user refuses
    * - security: fileName should be provided by the editor, so it should be
    * trustworthy: check?
    * - Users should probably have a command that interrupts a running test

--- a/src/testCaseEditor.ts
+++ b/src/testCaseEditor.ts
@@ -405,25 +405,27 @@ async function promptSaveBeforeTest(documentUri: vscode.Uri): Promise<boolean> {
     return true; // No unsaved changes, proceed
   }
 
+  const messages = getLocalizedMessages(vscode.env.language);
+
   const choice = await vscode.window.showWarningMessage(
-    'The file has unsaved changes. Save before running test?',
+    messages.unsavedChangesWarning,
     { modal: true },
-    'Save and Run',
-    'Run Without Saving'
+    { title: messages.saveAndRun, action: 'SaveAndRun' },
+    { title: messages.runWithoutSaving, action: 'RunWithoutSaving' }
   );
 
-  switch (choice) {
-    case 'Save and Run':
+  switch (choice?.action) {
+    case 'SaveAndRun':
       await saveSpecificDocument(documentUri);
       return true;
 
-    case 'Run Without Saving': {
+    case 'RunWithoutSaving': {
       const confirmed = await vscode.window.showWarningMessage(
-        'Test will run against the saved file content, not your current changes.',
+        messages.runAgainstSavedContent,
         { modal: true },
-        'Continue'
+        { title: messages.continue, action: 'Continue' }
       );
-      return confirmed === 'Continue';
+      return confirmed?.action === 'Continue';
     }
     default:
       return false;

--- a/src/testCaseEditor.ts
+++ b/src/testCaseEditor.ts
@@ -348,6 +348,28 @@ export function getLanguageFromUri(uri: vscode.Uri): string {
 }
 
 /**
+ * Find the tab for a custom document
+ * @param uri The URI of the custom document
+ * @returns The tab for the custom document
+ * @throws Error if no tab is found for the given URI
+ */
+function findCustomDocumentTab(uri: vscode.Uri): vscode.Tab {
+  const tab = vscode.window.tabGroups.all
+    .flatMap((group) => group.tabs)
+    .find(
+      (tab) =>
+        tab.input instanceof vscode.TabInputCustom &&
+        tab.input.uri.toString() === uri.toString()
+    );
+
+  if (!tab) {
+    throw new Error(`No tab found for custom document: ${uri.toString()}`);
+  }
+
+  return tab;
+}
+
+/**
  * Check if a custom document has unsaved changes.
  * Workaround using the tab API because vs code does not
  * expose the dirty state of a custom document even though
@@ -357,18 +379,7 @@ export function getLanguageFromUri(uri: vscode.Uri): string {
  * @throws Error if no tab is found for the given URI
  */
 function isCustomDocumentDirty(uri: vscode.Uri): boolean {
-  const tab = vscode.window.tabGroups.all
-    .flatMap((group) => group.tabs)
-    .find(
-      (tab) =>
-        tab.input instanceof vscode.TabInputCustom &&
-        tab.input.uri.toString() === uri.toString()
-    );
-
-  if (!tab) {
-    throw new Error(`No tab found for custom document: ${uri.toString()}`);
-  }
-
+  const tab = findCustomDocumentTab(uri);
   return tab.isDirty;
 }
 
@@ -378,17 +389,7 @@ function isCustomDocumentDirty(uri: vscode.Uri): boolean {
  */
 async function saveSpecificDocument(uri: vscode.Uri): Promise<void> {
   // Verify the tab exists first
-  const tab = vscode.window.tabGroups.all
-    .flatMap((group) => group.tabs)
-    .find(
-      (tab) =>
-        tab.input instanceof vscode.TabInputCustom &&
-        tab.input.uri.toString() === uri.toString()
-    );
-
-  if (!tab) {
-    throw new Error(`No tab found for custom document: ${uri.toString()}`);
-  }
+  findCustomDocumentTab(uri);
 
   // Now save the active document (since we clicked on the run button
   // we assume that the active document is the right one)

--- a/src/testCaseEditor.ts
+++ b/src/testCaseEditor.ts
@@ -184,7 +184,11 @@ export class TestCaseEditorProvider
           const shouldProceed = await promptSaveBeforeTest(document.uri);
 
           if (!shouldProceed) {
-            return; // User cancelled
+            // User cancelled
+            postMessageToWebView({
+              kind: 'TestRunResults',
+              value: { kind: 'Cancelled' },
+            });
           }
 
           const { scope, reset_outputs } = typed_msg.value;
@@ -201,7 +205,10 @@ export class TestCaseEditorProvider
               // the user has requested an outputs reset but
               // did not confirm -- we do not need to run the
               // test at all.
-              return;
+              postMessageToWebView({
+                kind: 'TestRunResults',
+                value: { kind: 'Cancelled' },
+              });
             }
           }
           const results = await this.testQueue.add(() =>

--- a/test-case-parser/test_case.atd
+++ b/test-case-parser/test_case.atd
@@ -124,8 +124,9 @@ type test_run_output = {
 }
 
 type test_run_results = [
-  | Error of string
-  | Ok of test_run_output
+  | Error of string (* System error while attempting to run the test *)
+  | Ok of test_run_output (* Ok means 'the test was run' -- there could be assertion failures *)
+  | Cancelled
 ]
 
 type test_generate_results = [


### PR DESCRIPTION
This prompts the user to save the current buffer before running a test as the 'run test' commands operates on files and not the buffer's text, so transparently running the file's contents was confusing for the user.

This PR also handles the enhances the cancellation handling