### PR TITLE
Adapt to Catala stdlib addition

### DIFF
--- a/catala-lsp.opam
+++ b/catala-lsp.opam
@@ -23,9 +23,6 @@ depends: [
   "linol"     { = "0.8" }
   "linol-lwt" { = "0.8" }
   "dap"       { = "1.0.6" }
-  "ppx_deriving_yojson"
-  "ppx_make"
-  "ppx_here"
   "qcheck"    { with-test & >= "0.21.3" }
   "tezt"      { with-test }
   "atdgen"    { build }

--- a/server/src/main_dap.ml
+++ b/server/src/main_dap.ml
@@ -287,7 +287,7 @@ let handle_evaluate logger rpc :
     in
     let* () =
       Format.kasprintf logger "@[<v 2>Message:@\n%s@]"
-        (Printexc.to_string (Runtime.Error (error, pl)))
+        (Printexc.to_string (Catala_runtime.Error (error, pl)))
     in
     send_stop ~description:"Exception" Reason.Exception
   | `Ok { DE.value = Exn { pos; exn = Internal pp }; _ }
@@ -630,21 +630,21 @@ let set_handlers rpc =
             Message.error
               ~extra_pos:(List.map (fun rp -> "", Expr.runtime_to_pos rp) spl)
               "During evaluation: %a." Format.pp_print_text
-              (Runtime.error_message error)
+              (Catala_runtime.error_message error)
           with Message.CompilerError content ->
             Format.asprintf "%t" (fun ppf ->
                 Message.Content.emit ~ppf content Error)
         in
         let* () = logger full_message in
-        let exception_id = Runtime.error_to_string error in
+        let exception_id = Catala_runtime.error_to_string error in
         let description = Some full_message in
         let break_mode : Exception_break_mode.t = Always in
         let details : Exception_details.t option =
           Some
             {
               message = None;
-              type_name = Some (Runtime.error_to_string error);
-              full_type_name = Some (Runtime.error_to_string error);
+              type_name = Some (Catala_runtime.error_to_string error);
+              full_type_name = Some (Catala_runtime.error_to_string error);
               evaluate_name = None;
               stack_trace = None;
               inner_exception = None;
@@ -716,4 +716,4 @@ let main () =
   let rpc = Debug_rpc.create ~in_:Lwt_io.stdin ~out:Lwt_io.stdout () in
   Lwt_main.run (launch rpc)
 
-let _ = main ()
+let () = main ()

--- a/server/src/type_printing.ml
+++ b/server/src/type_printing.ml
@@ -241,7 +241,7 @@ let svar_input_s_opt locale =
     | Pl -> assert false
   in
   function
-  | Runtime.NoInput -> None
+  | Catala_runtime.NoInput -> None
   | OnlyInput -> Some (input_s locale)
   | Reentrant -> Some (context_s locale)
 
@@ -274,7 +274,7 @@ let pp_scope_var
 
 let is_svar_internal (scope_ty : Scopelang.Ast.scope_var_ty) =
   (not (Mark.remove scope_ty.svar_io.io_output))
-  && Mark.remove scope_ty.svar_io.io_input = Runtime.NoInput
+  && Mark.remove scope_ty.svar_io.io_input = Catala_runtime.NoInput
 
 let pp_scope locale fmt (scope_name, scope_vars) =
   let open Format in

--- a/syntaxes/code_en.xml
+++ b/syntaxes/code_en.xml
@@ -34,7 +34,7 @@
         </dict>
         <dict>
           <key>match</key>
-          <string>\b(match|with\s+pattern|but\s+replace|fixed|by|decreasing|increasing|varies|with|we\s+have|let|in|such\s+that|exists|among|for|all|of|if|then|else|initial)\b</string>
+          <string>\b(match|with\s+pattern|but\s+replace|fixed|by|down|up|varies|with|we\s+have|let|in|such\s+that|exists|among|for|all|of|if|then|else|initial)\b</string>
           <key>name</key>
           <string>keyword.control.catala_code_en</string>
         </dict>
@@ -108,7 +108,7 @@
         </dict>
         <dict>
           <key>match</key>
-          <string>\b(integer|boolean|date|duration|money|text|decimal|number|sum)\b</string>
+          <string>\b(integer|boolean|date|duration|money|code_location|decimal|number|sum)\b</string>
           <key>name</key>
           <string>support.type.catala_code_en</string>
         </dict>

--- a/syntaxes/code_fr.xml
+++ b/syntaxes/code_fr.xml
@@ -34,7 +34,7 @@
         </dict>
         <dict>
           <key>match</key>
-          <string>\b(selon|sous\s+forme|mais\s+en\s+remplaçant|fixé|par|décroissant|croissant|varie|avec|on\s+a|soit|dans|tel\s+que|existe|pour|parmi|tout|de|si|alors|sinon|initial)\b</string>
+          <string>\b(selon|sous\s+forme|mais\s+en\s+remplaçant|fixé|par|inférieur|supérieur|varie|avec|on\s+a|soit|dans|tel\s+que|existe|pour|parmi|tout|de|si|alors|sinon|initial)\b</string>
           <key>name</key>
           <string>keyword.control.catala_code_fr</string>
         </dict>
@@ -114,7 +114,7 @@
         </dict>
         <dict>
           <key>match</key>
-          <string>\b(entier|booléen|date|durée|argent|texte|décimal|décret|loi|nombre|somme)\b</string>
+          <string>\b(entier|booléen|date|durée|argent|position_source|décimal|décret|loi|nombre|somme)\b</string>
           <key>name</key>
           <string>support.type.catala_code_fr</string>
         </dict>

--- a/syntaxes/en.xml
+++ b/syntaxes/en.xml
@@ -352,7 +352,7 @@
         </dict>
         <dict>
           <key>match</key>
-          <string>\b(match|with\s+pattern|but\s+replace|fixed|by|decreasing|increasing|varies|with|we\s+have|let|in|such\s+that|exists|contains|among|for|all|of|if|then|else|initial)\b</string>
+          <string>\b(match|with\s+pattern|but\s+replace|fixed|by|down|up|varies|with|we\s+have|let|in|such\s+that|exists|contains|among|for|all|of|if|then|else|initial)\b</string>
           <key>name</key>
           <string>keyword.control.catala_en</string>
         </dict>
@@ -426,7 +426,7 @@
         </dict>
         <dict>
           <key>match</key>
-          <string>\b(integer|boolean|date|duration|money|text|decimal|number|sum)\b</string>
+          <string>\b(integer|boolean|date|duration|money|code_location|decimal|number|sum)\b</string>
           <key>name</key>
           <string>support.type.catala_en</string>
         </dict>

--- a/syntaxes/fr.xml
+++ b/syntaxes/fr.xml
@@ -358,7 +358,7 @@
         </dict>
         <dict>
           <key>match</key>
-          <string>\b(selon|sous\s+forme|mais\s+en\s+remplaçant|fixé|par|décroissant|croissant|varie|avec|on\s+a|soit|dans|tel\s+que|existe|contient|pour|parmi|tout|de|si|alors|sinon|initial)\b</string>
+          <string>\b(selon|sous\s+forme|mais\s+en\s+remplaçant|fixé|par|inférieur|supérieur|varie|avec|on\s+a|soit|dans|tel\s+que|existe|contient|pour|parmi|tout|de|si|alors|sinon|initial)\b</string>
           <key>name</key>
           <string>keyword.control.catala_fr</string>
         </dict>
@@ -438,7 +438,7 @@
         </dict>
         <dict>
           <key>match</key>
-          <string>\b(entier|booléen|date|durée|argent|texte|décimal|décret|loi|nombre|somme)\b</string>
+          <string>\b(entier|booléen|date|durée|argent|position_source|décimal|décret|loi|nombre|somme)\b</string>
           <key>name</key>
           <string>support.type.catala_fr</string>
         </dict>

--- a/syntaxes/types_en.xml
+++ b/syntaxes/types_en.xml
@@ -30,7 +30,7 @@
         </dict>
         <dict>
           <key>match</key>
-          <string>\b(unit|integer|boolean|date|duration|money|decimal|anything\s+of\s+type|list\s+of|optional\s+of)\b</string>
+          <string>\b(unit|integer|boolean|date|duration|money|code_location|decimal|anything\s+of\s+type|list\s+of|optional\s+of)\b</string>
           <key>name</key>
           <string>support.type.catala_type_en</string>
         </dict>

--- a/syntaxes/types_fr.xml
+++ b/syntaxes/types_fr.xml
@@ -30,7 +30,7 @@
         </dict>
         <dict>
           <key>match</key>
-          <string>\b(unit|entier|booléen|date|durée|argent|décimal|n\&apos;importe\s+quel\s+de\s+type|liste\s+de|optionnel\s+de)\b</string>
+          <string>\b(unit|entier|booléen|date|durée|argent|position_source|décimal|n\&apos;importe\s+quel\s+de\s+type|liste\s+de|optionnel\s+de)\b</string>
           <key>name</key>
           <string>support.type.catala_type_fr</string>
         </dict>


### PR DESCRIPTION
This PR fixes the compilation and adapt the LSP and debugger to the stdlib feature merged in Catala.
It also add a hard dependency to `clerk` which must be accessible through the environment by the extension.
