### PR TITLE
Fix ocaml warn/error options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    env:
+      DUNE_PROFILE: check
     steps:
       - uses: actions/checkout@v4
 

--- a/dune
+++ b/dune
@@ -1,0 +1,21 @@
+(env
+ ; don't stop building because of warnings
+ (dev
+  (flags
+   (:standard -warn-error -a+8 -w -67)))
+ ; for CI runs: must fail on warnings
+ (check
+  (flags
+   (:standard
+    -w
+    +a-4-29-40-41-42-44-45-48-58-59-60-63-64-65-66-67-68-69-70
+    -warn-error
+    +a)))
+ ; let us see the warnings even in release mode, but non-fatal
+ (release
+  (flags
+   (:standard
+    -w
+    +a-4-29-40-41-42-44-45-48-58-59-60-63-64-65-66-67-68-69-70
+    -warn-error
+    -a))))


### PR DESCRIPTION
as for Catala: CI must fail on warnings, dev shouldn't, release shouldn't but shouldn't silence them either.

the lack of this setup made unhandled operator additions in Catala get unnoticed here.

I really can't understand how these defaults were chosen in dune 🤷🏿 