### PR TITLE
Add snippets for various Catala constructions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,16 @@
   },
   "main": "./dist/extension.js",
   "contributes": {
+    "snippets": [
+      {
+        "language": "catala_en",
+        "path": "./snippets/catala_en.json"
+      },
+      {
+        "language": "catala_fr",
+        "path": "./snippets/catala_fr.json"
+      }
+    ],
     "commands": [
       {
         "command": "catala.selectScope",

--- a/snippets/catala_en.json
+++ b/snippets/catala_en.json
@@ -1,0 +1,82 @@
+{
+  "Catala code block": {
+    "description": "Insert a Catala code-block",
+    "scope": "catala_en",
+    "prefix": ["code", "block", "```catala"],
+    "body": ["```catala", "$0", "```"]
+  },
+  "Catala metadata block": {
+    "description": "Insert a Catala metadata-block",
+    "scope": "catala_en",
+    "prefix": ["metadata", "block", "```catala-metadata"],
+    "body": ["```catala-metadata", "$0", "```"]
+  },
+  "declaration scope": {
+    "description": "Declare a Catala scope",
+    "scope": "catala_en",
+    "prefix": "declscope",
+    "body": ["declaration scope ${1:ScopeName}:", "  $0"]
+  },
+  "scope definition": {
+    "description": "Defines a Catala scope",
+    "scope": "catala_en",
+    "prefix": "scopedef",
+    "body": ["scope ${1:ScopeName}:", "  $0"]
+  },
+  "declaration struct": {
+    "description": "Declare a Catala structure",
+    "scope": "catala_en",
+    "prefix": "declstruct",
+    "body": ["declaration structure ${1:StructName}:", "  $0"]
+  },
+  "declaration enum": {
+    "description": "Declare a Catala enumeration",
+    "scope": "catala_en",
+    "prefix": "declenum",
+    "body": ["declaration enumeration ${1:EnumName}:", "  $0"]
+  },
+  "Existence in list test": {
+    "description": "Test whether an element in a list satisfies the test",
+    "scope": "catala_en",
+    "prefix": "exists",
+    "body": ["exists ${1:x} among ${2:lst}", "  such that ${3:test}"]
+  },
+  "For-All list elements test": {
+    "description": "Test that all element in a list satisfies the test",
+    "scope": "catala_en",
+    "prefix": "for all",
+    "body": ["for all ${1:x} among ${2:lst}", "  we have ${3:test}"]
+  },
+  "Map list": {
+    "description": "Transform each element of a list",
+    "scope": "catala_en",
+    "prefix": "map each",
+    "body": ["map each ${1:x} among ${2:lst}", "  to ${3:expr}"]
+  },
+  "Filter list": {
+    "description": "Filter out elements of a list that don't satisfy the test",
+    "scope": "catala_en",
+    "prefix": "list of",
+    "body": ["list of ${1:x} among ${2:lst}", "  such that ${3:test}"]
+  },
+  "Filter-Map list": {
+    "description": "Transform only the elements of a list that satisfy the test",
+    "scope": "catala_en",
+    "prefix": "map each such-that",
+    "body": [
+      "map each ${1:x} among ${2:lst}",
+      "  such that ${3:test}",
+      "  to ${4:expr}"
+    ]
+  },
+  "Combine list": {
+    "description": "Combine all the elements of a list",
+    "scope": "catala_en",
+    "prefix": "combine all",
+    "body": [
+      "combine all ${1:x} among ${2:lst}",
+      "  in ${3:acc} initially ${4:init}",
+      "  with ${5:aggregation}"
+    ]
+  }
+}

--- a/snippets/catala_fr.json
+++ b/snippets/catala_fr.json
@@ -1,0 +1,82 @@
+{
+  "Bloc de code catala": {
+    "description": "Insère un bloc de code Catala",
+    "scope": "catala_fr",
+    "prefix": ["code", "bloc", "```catala"],
+    "body": ["```catala", "$0", "```"]
+  },
+  "Bloc métadonnée catala": {
+    "description": "Insère un bloc de métadonnée Catala",
+    "scope": "catala_fr",
+    "prefix": ["metadata", "bloc", "```catala-metadata"],
+    "body": ["```catala-metadata", "$0", "```"]
+  },
+  "déclaration champ d'application": {
+    "description": "Déclare un champ d'application Catala",
+    "scope": "catala_fr",
+    "prefix": ["déclchamp"],
+    "body": ["déclaration champ d'application ${1:NomChamp}:", "  $0"]
+  },
+  "champ d'application": {
+    "description": "Définit un champ d'application Catala",
+    "scope": "catala_fr",
+    "prefix": ["champdéf"],
+    "body": ["champ d'application ${1:NomChamp}:", "  $0"]
+  },
+  "déclaration structure": {
+    "description": "Déclare une structure Catala",
+    "scope": "catala_fr",
+    "prefix": ["déclstruct"],
+    "body": ["déclaration structure ${1:NomStruct}:", "  $0"]
+  },
+  "déclaration énumération": {
+    "description": "Déclare une énumération Catala",
+    "scope": "catala_fr",
+    "prefix": ["déclénum"],
+    "body": ["déclaration énumération ${1:NomÉnum}:", "  $0"]
+  },
+  "Test d'existence dans une liste": {
+    "description": "Teste si un élément de la liste satisfait le test",
+    "scope": "catala_fr",
+    "prefix": "existe",
+    "body": ["existe ${1:x} parmi ${2:lst}", "  tel que ${3:test}"]
+  },
+  "Test Pour-Tout d'une liste": {
+    "description": "Teste que tous les éléments de la liste satisfont le test",
+    "scope": "catala_fr",
+    "prefix": "pour tout",
+    "body": ["pour tout ${1:x} parmi ${2:lst}", "  on a ${3:test}"]
+  },
+  "Transformation de liste": {
+    "description": "Transforme chaque élément d'une liste",
+    "scope": "catala_fr",
+    "prefix": "transforme chaque",
+    "body": ["transforme chaque ${1:x} parmi ${2:lst}", "  en ${3:expr}"]
+  },
+  "Filtrage d'une liste": {
+    "description": "Filtre les éléments d'une liste qui ne satisfont pas le test",
+    "scope": "catala_fr",
+    "prefix": "liste de",
+    "body": ["liste de ${1:x} parmi ${2:lst}", "  tel que ${3:test}"]
+  },
+  "Transformation-Filtrage de liste": {
+    "description": "Transforme seulement les éléments d'une liste qui sastisfont le test",
+    "scope": "catala_fr",
+    "prefix": "transforme chaque tel que",
+    "body": [
+      "transforme chaque ${1:x} parmi ${2:lst}",
+      "  tel que ${3:test}",
+      "  en ${4:expr}"
+    ]
+  },
+  "Combinaison de liste": {
+    "description": "Combine tous les éléments d'une liste",
+    "scope": "catala_fr",
+    "prefix": "combine tout",
+    "body": [
+      "combine tout ${1:x} parmi ${2:lst}",
+      "  dans ${3:acc} initialement ${4:init}",
+      "  avec ${5:expr}"
+    ]
+  }
+}


### PR DESCRIPTION
This PR adds various french and english snippets for Catala:
- Markdown code blocks for code & metadata
- Scopes / structures / enumeration declarations
- Scopes definition
- Various list constructions

I tried to prevent the auto-complete from being a pain in the a** but it might still be annoying sometimes. Feedback is welcome.

<img width="858" height="188" alt="image" src="https://github.com/user-attachments/assets/eba7117d-d2a9-45d4-be06-b5204bd93738" />

=> Pressing enter =>

<img width="396" height="129" alt="image" src="https://github.com/user-attachments/assets/72e97f86-88f6-42ee-bf06-04a9c92039c4" />

Pressing tab will switch from one field to another.

Also, very useful for md fenced blocks : 

<img width="736" height="141" alt="image" src="https://github.com/user-attachments/assets/30dd27d4-0c3a-458a-9d1e-bed675e07428" />

=> Pressing enter =>

<img width="362" height="100" alt="image" src="https://github.com/user-attachments/assets/a4bf3c48-faec-416b-9e16-38073c99cdbf" />

With the cursor properly set.
