### PR TITLE
Ad hoc completion

### DIFF
--- a/server/src/doc_completion.ml
+++ b/server/src/doc_completion.ml
@@ -1,0 +1,649 @@
+(* This file is part of the Catala compiler, a specification language for tax
+   and social benefits computation rules. Copyright (C) 2026 Inria, contributor:
+   Vincent Botbol <vincent.botbol@inria.fr>
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License. *)
+(****************************************************************)
+
+open Server_state
+open Catala_utils
+open Utils
+open Shared_ast
+open Linol_lwt
+open Surface
+open Server_types
+
+let _lookup_suggestions doc_id diagnostics range =
+  let*? rmap = Doc_id.Map.find_opt doc_id diagnostics in
+  Range.Map.find_opt range rmap
+  |> function
+  | None -> None
+  | Some { range; lsp_error; _ } -> (
+    let*? lsp_error = lsp_error in
+    match lsp_error.suggestion with
+    | None | Some [] -> None
+    | Some suggs -> Some (range, suggs))
+
+let _lookup_suggestions_by_pos doc_id diagnostics range =
+  let open Linol_lwt in
+  _lookup_suggestions doc_id diagnostics range
+  |> function
+  | None -> None
+  | Some (range, completions) ->
+    Some
+      (List.map
+         (fun sugg ->
+           let textEdit = `TextEdit (TextEdit.create ~range ~newText:sugg) in
+           CompletionItem.create ~kind:Keyword ~label:sugg ~textEdit ())
+         completions)
+
+let[@ocaml.warning "-32"] pp_token =
+ fun fmt (lex, _, pos) ->
+  Format.fprintf fmt "%s:%s" lex Pos.(from_lpos pos |> to_string_shorter)
+
+let lex_line (doc : document_state) ~content (pos : Position.t) =
+  let lexbuf = Sedlexing.Utf8.from_string content in
+  let lexer =
+    match doc.locale with
+    | En -> Lexer_en.lexer
+    | Fr -> Lexer_fr.lexer
+    | Pl -> Lexer_pl.lexer
+  in
+  let real_lpos = pos.line + 1 in
+  let line_tokens =
+    try
+      Lexer_common.with_lexing_context (doc.document_id :> string)
+      @@ fun () ->
+      let rec loop acc =
+        let token = lexer lexbuf in
+        let ((l, _r) as lpos) = Sedlexing.lexing_positions lexbuf in
+        let lnum = l.Lexing.pos_lnum in
+        if token = EOF || lnum > real_lpos then Option.map List.rev acc
+        else if lnum < pos.line then
+          (* skip *)
+          loop acc
+        else if l.Lexing.pos_lnum = real_lpos then
+          if !Lexer_common.context <> Code then loop acc
+          else
+            let elt = Sedlexing.Utf8.lexeme lexbuf, token, lpos in
+            match acc with
+            | None -> loop (Some [elt])
+            | Some acc -> loop (Some (elt :: acc))
+        else loop acc
+      in
+      let r = loop None in
+      (* Flush potential delayed errors *)
+      (try Message.report_delayed_errors_if_any () with _ -> ());
+      r
+    with e ->
+      begin
+        (match e with
+        | Message.CompilerError c ->
+          Log.warn (fun m ->
+              m "lexing exception: %t" (fun ppf ->
+                  Message.Content.emit ~ppf c Error))
+        | Message.CompilerErrors l ->
+          Log.warn (fun m ->
+              List.iter
+                (fun (c, _) ->
+                  m "lexing exception: %t" (fun ppf ->
+                      Message.Content.emit ~ppf c Error))
+                l)
+        | e ->
+          Log.warn (fun m ->
+              m "uncaught lexing exception: %s" (Printexc.to_string e)));
+        None
+      end
+  in
+  line_tokens
+
+let retrieve_tokens (doc : document_state) ~content (pos : Position.t) =
+  let*? line = lex_line (doc : document_state) ~content (pos : Position.t) in
+  let real_cpos = pos.Position.character + 1 in
+  let rec loop rev_preds = function
+    | ((_, _, (l, r)) as tok) :: tl ->
+      let lc = l.Lexing.pos_cnum - l.Lexing.pos_bol + 1 in
+      let rc = r.Lexing.pos_cnum - r.Lexing.pos_bol + 1 in
+      if lc <= real_cpos && real_cpos <= rc then
+        let trim_token (_lexem, t, p) =
+          let trim_str s = String.sub s 0 (real_cpos - lc) in
+          match t with
+          | Tokens.UIDENT s ->
+            let ts = trim_str s in
+            ts, Tokens.UIDENT ts, p
+          | LIDENT s ->
+            let ts = trim_str s in
+            ts, LIDENT ts, p
+          | _ -> tok
+        in
+        trim_token tok :: rev_preds, tl
+      else loop (tok :: rev_preds) tl
+    | [] -> (* shouldn't happen *) rev_preds, []
+  in
+  Some (loop [] line)
+
+let lookup_alias_name =
+  let en_names =
+    [
+      "Date";
+      "Duration";
+      "MonthYear";
+      "Period";
+      "Money";
+      "Integer";
+      "Decimal";
+      "List";
+    ]
+  in
+  let en_aliases = List.map (fun s -> s ^ "_en") en_names in
+  let fr_aliases = List.map (fun s -> s ^ "_fr") en_names in
+  let fr_names =
+    [
+      "Date";
+      "Durée";
+      "MoisAnnée";
+      "Période";
+      "Argent";
+      "Entier";
+      "Décimal";
+      "Liste";
+    ]
+  in
+  let en_alias_map = String.Map.of_list (List.combine en_aliases en_names) in
+  let fr_alias_map = String.Map.of_list (List.combine fr_aliases fr_names) in
+  let lookup_alias_name lang s =
+    match lang with
+    | Catala_utils.Global.Fr -> String.Map.find s fr_alias_map
+    | Catala_utils.Global.En | _ -> String.Map.find s en_alias_map
+  in
+  lookup_alias_name
+
+type completion = {
+  label : string;
+  detail : string;
+  kind : CompletionItemKind.t;
+  documentation :
+    [ `MarkupContent of MarkupContent.t | `String of string ] option;
+}
+
+module Kind = struct
+  type t =
+    | Module of ModuleName.t
+    | StdlibModule of (ModuleName.t * string (* alias *))
+    | Struct of StructName.t
+    | Enum of EnumName.t
+    | Constructor of EnumConstructor.t
+    | Scope of ScopeName.t
+    | Topdef of {
+        name : TopdefName.t;
+        ty : Shared_ast.typ;
+        extra_doc : string option;
+      }
+    | ScopeVar of { name : ScopeVar.t; ty : Shared_ast.typ }
+    | StructField of { name : StructField.t; ty : Shared_ast.typ }
+    | Keyword of { lexeme : string; token : Tokens.token }
+
+  let to_string = function
+    | Module m -> ModuleName.to_string m
+    | StdlibModule (_m, alias) -> alias
+    | Struct s -> StructName.base s
+    | Enum e -> EnumName.base e
+    | Constructor c -> EnumConstructor.to_string c
+    | Scope s -> ScopeName.base s
+    | Topdef { name; _ } -> TopdefName.base name
+    | ScopeVar { name; _ } -> ScopeVar.to_string name
+    | StructField { name; _ } -> StructField.to_string name
+    | Keyword { lexeme; _ } -> lexeme
+
+  let[@ocaml.warning "-32"] format ppf k =
+    match k with
+    | Module _ -> Format.fprintf ppf "Module(%s)" (to_string k)
+    | StdlibModule _ -> Format.fprintf ppf "StdlibModule(%s)" (to_string k)
+    | Struct _ -> Format.fprintf ppf "Struct(%s)" (to_string k)
+    | Enum _ -> Format.fprintf ppf "Enum(%s)" (to_string k)
+    | Constructor _ -> Format.fprintf ppf "Constructor(%s)" (to_string k)
+    | Scope _ -> Format.fprintf ppf "Scope(%s)" (to_string k)
+    | Topdef _ -> Format.fprintf ppf "Topdef(%s)" (to_string k)
+    | ScopeVar { ty; _ } ->
+      Format.fprintf ppf "ScopeVar(%s, %a)" (to_string k) Shared_ast.Print.typ
+        ty
+    | StructField { ty; _ } ->
+      Format.fprintf ppf "StructField(%s, %a)" (to_string k)
+        Shared_ast.Print.typ ty
+    | Keyword { lexeme; _ } -> Format.fprintf ppf "Keyword(%s)" lexeme
+
+  let itemkind : t -> completion =
+   fun k ->
+    let doc ?extra_doc ty =
+      let extra_doc =
+        match extra_doc with None -> "" | Some s -> Format.sprintf "\n\n%s" s
+      in
+      Some
+        (`MarkupContent
+           (MarkupContent.create ~kind:MarkupKind.Markdown
+              ~value:
+                (Format.asprintf "`%a`%s" Shared_ast.Print.typ ty extra_doc)))
+    in
+    let label, detail, kind, documentation =
+      match k with
+      | Module m ->
+        ModuleName.to_string m, "Module", CompletionItemKind.Module, None
+      | StdlibModule (_m, alias) -> alias, "Stdlib", Module, None
+      | Struct s -> StructName.base s, "Structure", Struct, None
+      | Enum e -> EnumName.base e, "Enumeration", Enum, None
+      | Constructor c ->
+        EnumConstructor.to_string c, "Constructor", Constructor, None
+      | Scope s -> ScopeName.base s, "Scope", Function, None
+      | Topdef { name; ty; extra_doc } ->
+        TopdefName.base name, "Function", Function, doc ?extra_doc ty
+      | ScopeVar { name; ty } ->
+        ScopeVar.to_string name, "Variable", Variable, doc ty
+      | StructField { name; ty } ->
+        StructField.to_string name, "Field", Field, doc ty
+      | Keyword { lexeme; _ } -> lexeme, "Keyword", Keyword, None
+    in
+    { label; detail; kind; documentation }
+
+  let to_completion : t -> Linol_lwt.CompletionItem.t =
+   fun k ->
+    let { label; detail; kind; documentation } = itemkind k in
+    CompletionItem.create ~label ~detail ~kind ?documentation ()
+
+  module Set = struct
+    include Set.Make (struct
+      type nonrec t = t
+
+      let compare l r =
+        match l, r with
+        | Module l, Module r -> ModuleName.compare l r
+        | StdlibModule (l, _), StdlibModule (r, _) -> ModuleName.compare l r
+        | Struct l, Struct r -> StructName.compare l r
+        | Enum l, Enum r -> EnumName.compare l r
+        | Constructor l, Constructor r -> EnumConstructor.compare l r
+        | Scope l, Scope r -> ScopeName.compare l r
+        | Topdef { name = l; _ }, Topdef { name = r; _ } ->
+          TopdefName.compare l r
+        | ScopeVar { name = l; _ }, ScopeVar { name = r; _ } ->
+          ScopeVar.compare l r
+        | l, r -> compare l r
+    end)
+  end
+end
+
+module CompletionMap = String.Map
+
+type prefix =
+  | PartialUident of string
+  | PartialLident of string
+  | FullUident of string
+  | FullLident of string
+
+let update ?prefix kind m =
+  let name = Kind.to_string kind in
+  match prefix with
+  | Some (FullLident f | FullUident f) when not (String.equal name f) -> m
+  | Some (PartialLident prefix | PartialUident prefix)
+    when not (String.starts_with ~prefix name) ->
+    m
+  | None | Some (FullLident _ | FullUident _ | PartialLident _ | PartialUident _)
+    ->
+    String.Map.update name
+      (function
+        | None -> Some (Kind.Set.singleton kind)
+        | Some s -> Some (Kind.Set.add kind s))
+      m
+
+let update_all ?prefix map kinds =
+  Kind.Set.fold (fun k m -> update ?prefix k m) kinds map
+
+let lookup_modules ?prefix (prg : typed Scopelang.Ast.program) m =
+  let stdlib_modules, nonstdlib_modules =
+    ModuleName.Map.partition
+      (fun _m -> function
+        | { intf_id = { is_stdlib = true; _ }; _ } -> true
+        | { intf_id = { is_stdlib = false; _ }; _ } -> false)
+      prg.program_ctx.ctx_modules
+  in
+  let stdlib_modules =
+    ModuleName.Map.to_seq stdlib_modules
+    |> Seq.filter_map (fun (m, _) ->
+        if String.starts_with ~prefix:"Stdlib_" (ModuleName.to_string m) then
+          None
+        else
+          let alias =
+            lookup_alias_name prg.program_lang (ModuleName.to_string m)
+          in
+          Some (Kind.StdlibModule (m, alias)))
+    |> Kind.Set.of_seq
+  in
+  let nonstdlib_modules =
+    ModuleName.Map.to_seq nonstdlib_modules
+    |> Seq.map (fun (m, _) -> Kind.Module m)
+    |> Kind.Set.of_seq
+  in
+  update_all ?prefix m (Kind.Set.union stdlib_modules nonstdlib_modules)
+
+let lookup_scopes ?prefix ?modname (prg : typed Scopelang.Ast.program) m =
+  let scopes =
+    match modname with
+    | None -> prg.program_scopes
+    | Some m -> (
+      ModuleName.Map.find_opt m prg.program_modules
+      |> function None -> ScopeName.Map.empty | Some scopes -> scopes)
+  in
+  ScopeName.Map.to_seq scopes
+  |> Seq.map (fun (s, _) -> Kind.Scope s)
+  |> Kind.Set.of_seq
+  |> update_all ?prefix m
+
+let lookup_structs ?prefix ?modname (prg : typed Scopelang.Ast.program) m =
+  let structs =
+    match modname with
+    | None -> prg.program_ctx.ctx_structs
+    | Some m ->
+      StructName.Map.filter_map
+        (fun s v ->
+          let*? m' =
+            StructName.path s
+            |> List.rev
+            |> function [] -> None | h :: _ -> Some h
+          in
+          if ModuleName.equal m m' then Some v else None)
+        prg.program_ctx.ctx_structs
+  in
+  StructName.Map.to_seq structs
+  |> Seq.map (fun (s, _) -> Kind.Struct s)
+  |> Kind.Set.of_seq
+  |> update_all ?prefix m
+
+let lookup_struct_fields
+    ?prefix
+    ~structname
+    (prg : typed Scopelang.Ast.program)
+    m =
+  let r = StructName.Map.find_opt structname prg.program_ctx.ctx_structs in
+  match r with
+  | None -> m
+  | Some fields ->
+    StructField.Map.to_seq fields
+    |> Seq.map (fun (name, ty) -> Kind.StructField { name; ty })
+    |> Kind.Set.of_seq
+    |> update_all ?prefix m
+
+let lookup_enums ?prefix ?modname (prg : typed Scopelang.Ast.program) m =
+  let enums =
+    match modname with
+    | None -> prg.program_ctx.ctx_enums
+    | Some m ->
+      EnumName.Map.filter_map
+        (fun s v ->
+          let*? m' =
+            EnumName.path s
+            |> List.rev
+            |> function [] -> None | h :: _ -> Some h
+          in
+          if ModuleName.equal m m' then Some v else None)
+        prg.program_ctx.ctx_enums
+  in
+  EnumName.Map.to_seq enums
+  |> Seq.map (fun (s, _) -> Kind.Enum s)
+  |> Kind.Set.of_seq
+  |> update_all ?prefix m
+
+let lookup_constructors ?prefix ?enum_name (prg : typed Scopelang.Ast.program) m
+    =
+  let constructors =
+    match enum_name with
+    | None ->
+      Ident.Map.fold
+        (fun _id enum_map acc ->
+          EnumName.Map.to_seq enum_map
+          |> Seq.map snd
+          |> fun sq -> EnumConstructor.Set.add_seq sq acc)
+        prg.program_ctx.ctx_enum_constrs EnumConstructor.Set.empty
+    | Some e -> (
+      let enum_opt = EnumName.Map.find_opt e prg.program_ctx.ctx_enums in
+      match enum_opt with
+      | None -> EnumConstructor.Set.empty
+      | Some cs ->
+        EnumConstructor.Map.to_seq cs
+        |> Seq.map fst
+        |> EnumConstructor.Set.of_seq)
+  in
+  EnumConstructor.Set.to_seq constructors
+  |> Seq.map (fun s -> Kind.Constructor s)
+  |> Kind.Set.of_seq
+  |> update_all ?prefix m
+
+let lookup_topdefs ?prefix ?modname (prg : typed Scopelang.Ast.program) m =
+  let extract_doc td =
+    TopdefName.get_info td
+    |> Mark.get
+    |> Pos.attrs
+    |> List.filter_map (function Doc (d, _) -> Some d | _ -> None)
+    |> String.concat "\n"
+    |> Option.some
+  in
+  let topdefs =
+    match modname with
+    | None ->
+      (* Discard topdefs from other modules -- in the future, we would like to
+         insert the required module *)
+      TopdefName.Map.filter_map
+        (fun td (typ, _vis) ->
+          let extra_doc = extract_doc td in
+          if TopdefName.path td = [] then Some (typ, extra_doc) else None)
+        prg.program_ctx.ctx_topdefs
+    | Some m ->
+      TopdefName.Map.filter_map
+        (fun td (typ, _vis) ->
+          let*? m' =
+            TopdefName.path td
+            |> List.rev
+            |> function [] -> None | h :: _ -> Some h
+          in
+          let extra_doc = extract_doc td in
+          if ModuleName.equal m m' then Some (typ, extra_doc) else None)
+        prg.program_ctx.ctx_topdefs
+  in
+  TopdefName.Map.to_seq topdefs
+  |> Seq.map (fun (name, (ty, extra_doc)) ->
+      Kind.Topdef { name; ty; extra_doc })
+  |> Kind.Set.of_seq
+  |> update_all ?prefix m
+
+let lookup_scopevars ?prefix (prg : typed Scopelang.Ast.program) m =
+  ScopeName.Map.to_seq prg.program_scopes
+  |> Seq.map (fun (_, sdecl) ->
+      ScopeVar.Map.to_seq (Mark.remove sdecl).Scopelang.Ast.scope_sig
+      |> Seq.concat_map (fun (name, (ty : Scopelang.Ast.scope_var_ty)) ->
+          List.to_seq
+          @@ List.sort_uniq compare
+               [
+                 Kind.ScopeVar { name; ty = ty.svar_in_ty };
+                 Kind.ScopeVar { name; ty = ty.svar_out_ty };
+               ]))
+  |> Seq.concat
+  |> Kind.Set.of_seq
+  |> update_all ?prefix m
+
+let find_qualifiers prg uident =
+  let prefix = FullUident uident in
+  CompletionMap.empty |> lookup_enums ~prefix prg |> lookup_modules ~prefix prg
+
+let follow_ups ?prefix prg (kind : Kind.t) m =
+  match kind, prefix with
+  | _, Some (FullUident _ | FullLident _) -> (* Not a partial prefix *) m
+  | Enum _, Some (PartialLident _) -> m
+  | (Module modname | StdlibModule (modname, _)), None ->
+    m
+    |> lookup_topdefs ?prefix ~modname prg
+    |> lookup_structs ?prefix ~modname prg
+    |> lookup_enums ?prefix ~modname prg
+    |> lookup_scopes ?prefix ~modname prg
+  | (Module modname | StdlibModule (modname, _)), Some (PartialUident _) ->
+    m
+    |> lookup_structs ?prefix ~modname prg
+    |> lookup_enums ?prefix ~modname prg
+    |> lookup_scopes ?prefix ~modname prg
+  | (Module modname | StdlibModule (modname, _)), Some (PartialLident _) ->
+    m |> lookup_topdefs ?prefix ~modname prg
+  | Enum enum_name, _ -> lookup_constructors ?prefix ~enum_name prg m
+  | ScopeVar { ty = TStruct structname, _; _ }, _
+  | ScopeVar { ty = TDefault (TStruct structname, _), _; _ }, _ ->
+    lookup_struct_fields ?prefix ~structname prg m
+  | Struct _, _
+  | Constructor _, _
+  | Scope _, _
+  | Topdef _, _
+  | ScopeVar _, _
+  | StructField _, _
+  | Keyword _, _ ->
+    m
+
+let lookup_keywords ~prefix (prg : typed Scopelang.Ast.program) m =
+  let token_list =
+    match prg.program_lang with
+    | En -> Lexer_en.token_list
+    | Fr -> Lexer_fr.token_list
+    | Pl -> Lexer_pl.token_list
+  in
+  List.map (fun (lexeme, token) -> Kind.Keyword { lexeme; token }) token_list
+  |> Kind.Set.of_list
+  |> update_all ~prefix m
+
+let tok_to_prefix full = function
+  | Tokens.UIDENT s -> if full then FullUident s else PartialUident s
+  | Tokens.LIDENT s -> if full then FullLident s else PartialLident s
+  | _ -> assert false
+
+let partial_prefix = tok_to_prefix false
+let[@ocaml.warning "-32"] full_prefix = tok_to_prefix true
+
+let uident_dot_prefix uident ?prefix_tok prg =
+  let map = find_qualifiers prg uident in
+  String.Map.fold
+    (fun _qual s m ->
+      let prefix = Option.map partial_prefix prefix_tok in
+      Kind.Set.fold (fun k m -> follow_ups ?prefix prg k m) s m)
+    map CompletionMap.empty
+
+let single_uident prefix_tok prg =
+  let prefix = tok_to_prefix false prefix_tok in
+  CompletionMap.empty
+  |> lookup_modules ~prefix prg
+  |> lookup_structs ~prefix prg
+  |> lookup_enums ~prefix prg
+  |> lookup_constructors ~prefix prg
+  |> lookup_scopes ~prefix prg
+
+let single_lident ?(full = false) prefix_tok prg =
+  let prefix = tok_to_prefix full prefix_tok in
+  CompletionMap.empty
+  |> lookup_topdefs ~prefix prg
+  |> lookup_scopevars ~prefix prg
+  |> lookup_keywords ~prefix prg
+(* TODO: also inspect the AST *)
+
+let lident_dot_prefix lident ?prefix_tok prg =
+  let map = single_lident ~full:true (LIDENT lident) prg in
+  let prefix = Option.map partial_prefix prefix_tok in
+  String.Map.fold
+    (fun _qual s m -> Kind.Set.fold (fun k m -> follow_ups ?prefix prg k m) s m)
+    map CompletionMap.empty
+
+let to_completions completion_map =
+  CompletionMap.map
+    (fun kinds ->
+      (* Scope always have a associated struct => filter it out to prevent
+         spurious completions *)
+      if Kind.Set.exists (function Kind.Scope _ -> true | _ -> false) kinds
+      then Kind.Set.filter (function Kind.Struct _ -> false | _ -> true) kinds
+      else kinds)
+    completion_map
+  |> CompletionMap.bindings
+  |> List.concat_map (fun (_, sk) ->
+      Kind.Set.elements sk |> List.map Kind.to_completion)
+  |> Utils.option_of_list
+
+let lookup_completions (doc : document_state) ~doc_content pos =
+  (* TODO: capture the 'scope' using the tokens to help completion, e.g., we
+     know that we are in the scope S so on 'definition ' we know which variables
+     are allowed. *)
+  let open Surface in
+  let*? rev_tokens, _next_tokens =
+    retrieve_tokens doc ~content:doc_content pos
+  in
+  let on_token =
+    match rev_tokens with
+    | [] -> false
+    | (_, _, (_, rp)) :: _ ->
+      let rc = rp.Lexing.pos_cnum - rp.Lexing.pos_bol + 1 in
+      pos.Position.character + 1 <= rc
+  in
+  let open Tokens in
+  let r =
+    match rev_tokens with
+    | (_, ((UIDENT _ | LIDENT _) as tok), _) (* <= curr token *)
+      :: (_, DOT, _)
+      :: (_, UIDENT qualif, _)
+      :: _ ->
+      let*? last_valid_result = doc.last_valid_result in
+      let prg = last_valid_result.prg in
+      let completion_map = uident_dot_prefix qualif ~prefix_tok:tok prg in
+      to_completions completion_map
+    | (_, DOT, _) :: (_, UIDENT qualif, _) :: _ ->
+      let*? last_valid_result = doc.last_valid_result in
+      let prg = last_valid_result.prg in
+      let completions_map = uident_dot_prefix qualif prg in
+      to_completions completions_map
+    | (_, DOT, _) :: (_, LIDENT qualif, _) :: _ ->
+      let*? last_valid_result = doc.last_valid_result in
+      let prg = last_valid_result.prg in
+      lident_dot_prefix qualif prg |> to_completions
+    | (_, (LIDENT _ as prefix_tok), _)
+      :: (_, DOT, _)
+      :: (_, LIDENT qualif, _)
+      :: _ ->
+      let*? last_valid_result = doc.last_valid_result in
+      let prg = last_valid_result.prg in
+      lident_dot_prefix ~prefix_tok qualif prg |> to_completions
+    | (_, (UIDENT _s as tok), _) :: _ ->
+      let*? last_valid_result = doc.last_valid_result in
+      let prg = last_valid_result.prg in
+      single_uident tok prg |> to_completions
+    | (_, (LIDENT _s as tok), _) :: _ when on_token ->
+      let*? last_valid_result = doc.last_valid_result in
+      let prg = last_valid_result.prg in
+      single_lident tok prg |> to_completions
+    | _ -> None
+  in
+  (* Log.debug (fun m -> *)
+  (*     m "@[<v 2>Full completion candidates:@ %a@]" *)
+  (*       (pp_opt *)
+  (*          Format.( *)
+  (*            pp_print_list (fun fmt { CompletionItem.label; _ } -> *)
+  (*                Format.pp_print_string fmt label))) *)
+  (*       r); *)
+  r
+
+let lookup_completions
+    (doc : document_state)
+    ~doc_content
+    pos
+    (_diagnostics : diagnostic Range.Map.t Doc_id.Map.t) =
+  (* FIXME: restore parsing "contextual" completions *)
+  try lookup_completions doc ~doc_content pos
+  with e ->
+    Message.warning "Uncaught completion exception: %s" (Printexc.to_string e);
+    None

--- a/server/src/doc_completion.ml
+++ b/server/src/doc_completion.ml
@@ -48,8 +48,8 @@ let _lookup_suggestions_by_pos doc_id diagnostics range =
          completions)
 
 let[@ocaml.warning "-32"] pp_token =
- fun fmt (lex, _, pos) ->
-  Format.fprintf fmt "%s:%s" lex Pos.(from_lpos pos |> to_string_shorter)
+ fun fmt (lex, (_tok : Tokens.token), pos) ->
+  Format.fprintf fmt "'%s':%s" lex Pos.(from_lpos pos |> to_string_shorter)
 
 let lex_line (doc : document_state) ~content (pos : Position.t) =
   let lexbuf = Sedlexing.Utf8.from_string content in
@@ -73,12 +73,10 @@ let lex_line (doc : document_state) ~content (pos : Position.t) =
           (* skip *)
           loop acc
         else if l.Lexing.pos_lnum = real_lpos then
-          if !Lexer_common.context <> Code then loop acc
-          else
-            let elt = Sedlexing.Utf8.lexeme lexbuf, token, lpos in
-            match acc with
-            | None -> loop (Some [elt])
-            | Some acc -> loop (Some (elt :: acc))
+          let elt = Sedlexing.Utf8.lexeme lexbuf, token, lpos in
+          match acc with
+          | None -> loop (Some [elt])
+          | Some acc -> loop (Some (elt :: acc))
         else loop acc
       in
       let r = loop None in
@@ -99,7 +97,11 @@ let lex_line (doc : document_state) ~content (pos : Position.t) =
                   m "lexing exception: %t" (fun ppf ->
                       Message.Content.emit ~ppf c Error))
                 l)
-        | e ->
+        | Surface.Lexer_common.Lexing_error (p, e) ->
+          Log.warn (fun m ->
+              m "uncaught lexing exception at %s: %s" (Pos.to_string_shorter p)
+                e)
+        | _ ->
           Log.warn (fun m ->
               m "uncaught lexing exception: %s" (Printexc.to_string e)));
         None
@@ -130,7 +132,17 @@ let retrieve_tokens (doc : document_state) ~content (pos : Position.t) =
       else loop (tok :: rev_preds) tl
     | [] -> (* shouldn't happen *) rev_preds, []
   in
-  Some (loop [] line)
+  let rev_tokens, next_tokens = loop [] line in
+  let rev_tokens =
+    (* Filter spurious tokens *)
+    match rev_tokens with
+    | (_, Tokens.END_DIRECTIVE, _) :: rev_tokens -> rev_tokens
+    | r -> r
+  in
+  (* Log.debug (fun m -> *)
+  (*     (m "@[<h>Line rev tokens: %a@]" Format.(pp_print_list pp_token)) *)
+  (*       rev_tokens); *)
+  Some (rev_tokens, next_tokens)
 
 type completion = {
   label : string;
@@ -143,6 +155,7 @@ type completion = {
 module Kind = struct
   type t =
     | Module of ModuleName.t
+    | ModuleUsage of Ident.t
     | StdlibModule of { name : ModuleName.t; alias : string }
     | Struct of { name : StructName.t; fields : typ StructField.Map.t }
     | Enum of { name : EnumName.t; constrs : typ EnumConstructor.Map.t }
@@ -160,6 +173,7 @@ module Kind = struct
 
   let to_string = function
     | Module m -> ModuleName.to_string m
+    | ModuleUsage m -> m
     | StdlibModule { name = _m; alias } -> alias
     | Struct { name; _ } -> StructName.base name
     | Enum { name; _ } -> EnumName.base name
@@ -173,6 +187,7 @@ module Kind = struct
   let[@ocaml.warning "-32"] format ppf k =
     match k with
     | Module _ -> Format.fprintf ppf "Module(%s)" (to_string k)
+    | ModuleUsage _ -> Format.fprintf ppf "ModuleUsage(%s)" (to_string k)
     | StdlibModule _ -> Format.fprintf ppf "StdlibModule(%s)" (to_string k)
     | Struct _ -> Format.fprintf ppf "Struct(%s)" (to_string k)
     | Enum _ -> Format.fprintf ppf "Enum(%s)" (to_string k)
@@ -203,6 +218,7 @@ module Kind = struct
     let signature, doc =
       match k with
       | Module _ -> None, None (* TODO: print module content *)
+      | ModuleUsage _ -> None, None (* TODO: print module content *)
       | StdlibModule _ -> None, None (* TODO: print module content *)
       | Struct { name; fields } ->
         ( Some (Type_printing.struct_code ~markdown:true locale (name, fields)),
@@ -271,6 +287,7 @@ module Kind = struct
     let label, detail, kind =
       match k with
       | Module m -> ModuleName.to_string m, "Module", CompletionItemKind.Module
+      | ModuleUsage m -> m, "Module", CompletionItemKind.Module
       | StdlibModule { alias; _ } -> alias, "Stdlib Module", Module
       | Struct { name; _ } -> StructName.base name, "Structure", Struct
       | Enum { name; _ } -> EnumName.base name, "Enumeration", Enum
@@ -291,7 +308,8 @@ module Kind = struct
   let to_completion locale : t -> Linol_lwt.CompletionItem.t =
    fun k ->
     let { label; detail; kind; documentation } = itemkind locale k in
-    CompletionItem.create ~label ~detail ~kind ?documentation ()
+    CompletionItem.create ~insertText:label ~label ~detail ~kind ?documentation
+      ()
 
   module Set = struct
     include Set.Make (struct
@@ -375,6 +393,23 @@ let lookup_modules ?prefix (prg : typed Scopelang.Ast.program) m =
     |> Kind.Set.of_seq
   in
   update_all ?prefix m (Kind.Set.union stdlib_modules nonstdlib_modules)
+
+let lookup_project_modules
+    ?prefix
+    (prg : typed Scopelang.Ast.program)
+    ({ known_modules; _ } : Projects.project)
+    m =
+  let open Projects in
+  let is_eq_prg_mod_name =
+    match prg.program_module_name with
+    | None -> fun _ -> false
+    | Some (mn, _) -> String.equal (ModuleName.to_string mn)
+  in
+  ModuleMap.to_seq known_modules
+  |> Seq.filter_map (fun (m, _) ->
+      if is_eq_prg_mod_name m then None else Some (Kind.ModuleUsage m))
+  |> Kind.Set.of_seq
+  |> update_all ?prefix m
 
 let lookup_scopes ?prefix ?modname (prg : typed Scopelang.Ast.program) m =
   let scopes =
@@ -594,7 +629,8 @@ let follow_ups ?prefix prg (kind : Kind.t) m =
   | Topdef _, _
   | ScopeVar _, _
   | StructField _, _
-  | Keyword _, _ ->
+  | Keyword _, _
+  | ModuleUsage _, _ ->
     m
 
 let lookup_keywords ~prefix (prg : typed Scopelang.Ast.program) m =
@@ -609,6 +645,7 @@ let lookup_keywords ~prefix (prg : typed Scopelang.Ast.program) m =
   |> update_all ~prefix m
 
 let tok_to_prefix full = function
+  | Tokens.DIRECTIVE_ARG s -> if full then FullUident s else PartialUident s
   | Tokens.UIDENT s -> if full then FullUident s else PartialUident s
   | Tokens.LIDENT s -> if full then FullLident s else PartialLident s
   | _ -> assert false
@@ -648,6 +685,42 @@ let lident_dot_prefix lident ?prefix_tok prg =
     (fun _qual s m -> Kind.Set.fold (fun k m -> follow_ups ?prefix prg k m) s m)
     map CompletionMap.empty
 
+let directives ?prefix (prg : typed Scopelang.Ast.program) needs_space =
+  let using =
+    Kind.Keyword
+      {
+        lexeme = Type_printing.using_s prg.program_lang;
+        token = Tokens.MODULE_USE;
+      }
+  in
+  let def = Kind.Keyword { lexeme = "Module"; token = Tokens.MODULE_DEF } in
+  let l =
+    [using; def]
+    |> fun l ->
+    if needs_space then
+      List.filter_map
+        (function
+          | Kind.Keyword x ->
+            Some (Kind.Keyword { x with lexeme = " " ^ x.lexeme })
+          | _ -> None)
+        l
+    else l
+  in
+  update_all ?prefix CompletionMap.empty (Kind.Set.of_list l)
+
+let module_def ?prefix doc =
+  let mod_name =
+    File.basename (doc.document_id :> string)
+    |> File.remove_extension
+    |> String.capitalize_ascii
+  in
+  if prefix = None then
+    CompletionMap.singleton mod_name
+      Kind.(Set.singleton (ModuleUsage ("Module " ^ mod_name)))
+  else
+    update_all ?prefix CompletionMap.empty
+      Kind.(Set.singleton (ModuleUsage mod_name))
+
 let to_completions locale completion_map =
   CompletionMap.map
     (fun kinds ->
@@ -683,10 +756,27 @@ let lookup_completions (doc : document_state) ~doc_content pos =
   let open Tokens in
   let r =
     match rev_tokens with
+    | (_, ((UIDENT _ | DIRECTIVE_ARG _) as tok), _) :: (_, MODULE_USE, _) :: _
+      ->
+      lookup_project_modules prg doc.project ~prefix:(partial_prefix tok)
+        CompletionMap.empty
+    | (_, MODULE_USE, _) :: _ ->
+      lookup_project_modules prg doc.project CompletionMap.empty
+    | (_, (DIRECTIVE_ARG _ as tok), _)
+      :: (_, MODULE_DEF, _)
+      :: (_, BEGIN_DIRECTIVE, _)
+      :: _ ->
+      module_def ~prefix:(partial_prefix tok) doc
+    | (_, MODULE_DEF, _) :: (_, BEGIN_DIRECTIVE, _) :: _ -> module_def doc
+    | (_, ((UIDENT _ | DIRECTIVE_ARG _) as tok), _)
+      :: (_, BEGIN_DIRECTIVE, _)
+      :: _ ->
+      directives ~prefix:(partial_prefix tok) prg false
+    | (_, BEGIN_DIRECTIVE, _) :: _ -> directives prg on_token
     | (_, (UIDENT _s as tok), _) :: (_, OF, _) :: (_, OUTPUT, _) :: _ ->
       lookup_scopes prg ~prefix:(partial_prefix tok) CompletionMap.empty
     | (_, OF, _) :: (_, OUTPUT, _) :: _ -> lookup_scopes prg CompletionMap.empty
-    | (_, ((UIDENT _ | LIDENT _) as tok), _) (* <= curr token *)
+    | (_, ((UIDENT _ | LIDENT _) as tok), _)
       :: (_, DOT, _)
       :: (_, UIDENT qualif, _)
       :: _ ->
@@ -702,14 +792,15 @@ let lookup_completions (doc : document_state) ~doc_content pos =
     | (_, (LIDENT _s as tok), _) :: _ when on_token -> single_lident tok prg
     | _ -> CompletionMap.empty
   in
-  (* Log.debug (fun m -> *)
-  (*     m "@[<v 2>Full completion candidates:@ %a@]" *)
-  (*       (pp_opt *)
-  (*          Format.( *)
-  (*            pp_print_list (fun fmt { CompletionItem.label; _ } -> *)
-  (*                Format.pp_print_string fmt label))) *)
-  (*       r); *)
-  to_completions r
+  let completions = to_completions r in
+  Log.debug (fun m ->
+      m "@[<v 2>Completion candidates:@ %a@]"
+        (pp_opt
+           Format.(
+             pp_print_list (fun fmt { CompletionItem.label; _ } ->
+                 Format.fprintf fmt "'%s'" label)))
+        completions);
+  completions
 
 let lookup_completions
     (doc : document_state)

--- a/server/src/doc_completion.ml
+++ b/server/src/doc_completion.ml
@@ -132,42 +132,6 @@ let retrieve_tokens (doc : document_state) ~content (pos : Position.t) =
   in
   Some (loop [] line)
 
-let lookup_alias_name =
-  let en_names =
-    [
-      "Date";
-      "Duration";
-      "MonthYear";
-      "Period";
-      "Money";
-      "Integer";
-      "Decimal";
-      "List";
-    ]
-  in
-  let en_aliases = List.map (fun s -> s ^ "_en") en_names in
-  let fr_aliases = List.map (fun s -> s ^ "_fr") en_names in
-  let fr_names =
-    [
-      "Date";
-      "Durée";
-      "MoisAnnée";
-      "Période";
-      "Argent";
-      "Entier";
-      "Décimal";
-      "Liste";
-    ]
-  in
-  let en_alias_map = String.Map.of_list (List.combine en_aliases en_names) in
-  let fr_alias_map = String.Map.of_list (List.combine fr_aliases fr_names) in
-  let lookup_alias_name lang s =
-    match lang with
-    | Catala_utils.Global.Fr -> String.Map.find s fr_alias_map
-    | Catala_utils.Global.En | _ -> String.Map.find s en_alias_map
-  in
-  lookup_alias_name
-
 type completion = {
   label : string;
   detail : string;
@@ -179,27 +143,23 @@ type completion = {
 module Kind = struct
   type t =
     | Module of ModuleName.t
-    | StdlibModule of (ModuleName.t * string (* alias *))
-    | Struct of StructName.t
-    | Enum of EnumName.t
-    | Constructor of EnumConstructor.t
-    | Scope of ScopeName.t
-    | Topdef of {
-        name : TopdefName.t;
-        ty : Shared_ast.typ;
-        extra_doc : string option;
-      }
-    | ScopeVar of { name : ScopeVar.t; ty : Shared_ast.typ }
+    | StdlibModule of { name : ModuleName.t; alias : string }
+    | Struct of { name : StructName.t; fields : typ StructField.Map.t }
+    | Enum of { name : EnumName.t; constrs : typ EnumConstructor.Map.t }
+    | Constructor of { constr : EnumConstructor.t; enum_name : EnumName.t }
+    | Scope of { name : ScopeName.t; decl : typed Scopelang.Ast.scope_decl }
+    | Topdef of { name : TopdefName.t; ty : Shared_ast.typ }
+    | ScopeVar of { name : ScopeVar.t; ty : Scopelang.Ast.scope_var_ty }
     | StructField of { name : StructField.t; ty : Shared_ast.typ }
     | Keyword of { lexeme : string; token : Tokens.token }
 
   let to_string = function
     | Module m -> ModuleName.to_string m
-    | StdlibModule (_m, alias) -> alias
-    | Struct s -> StructName.base s
-    | Enum e -> EnumName.base e
-    | Constructor c -> EnumConstructor.to_string c
-    | Scope s -> ScopeName.base s
+    | StdlibModule { name = _m; alias } -> alias
+    | Struct { name; _ } -> StructName.base name
+    | Enum { name; _ } -> EnumName.base name
+    | Constructor { constr; _ } -> EnumConstructor.to_string constr
+    | Scope { name; _ } -> ScopeName.base name
     | Topdef { name; _ } -> TopdefName.base name
     | ScopeVar { name; _ } -> ScopeVar.to_string name
     | StructField { name; _ } -> StructField.to_string name
@@ -216,47 +176,100 @@ module Kind = struct
     | Topdef _ -> Format.fprintf ppf "Topdef(%s)" (to_string k)
     | ScopeVar { ty; _ } ->
       Format.fprintf ppf "ScopeVar(%s, %a)" (to_string k) Shared_ast.Print.typ
-        ty
+        ty.svar_out_ty
     | StructField { ty; _ } ->
       Format.fprintf ppf "StructField(%s, %a)" (to_string k)
         Shared_ast.Print.typ ty
     | Keyword { lexeme; _ } -> Format.fprintf ppf "Keyword(%s)" lexeme
 
-  let itemkind : t -> completion =
-   fun k ->
-    let doc ?extra_doc ty =
-      let extra_doc =
-        match extra_doc with None -> "" | Some s -> Format.sprintf "\n\n%s" s
+  let make_doc locale k =
+    let extract_doc get_info x =
+      let*? doc =
+        get_info x
+        |> Mark.get
+        |> Pos.attrs
+        |> List.filter_map (function Doc (d, _) -> Some d | _ -> None)
+        |> option_of_list
+        |> Option.map (String.concat "\n")
       in
-      Some
-        (`MarkupContent
-           (MarkupContent.create ~kind:MarkupKind.Markdown
-              ~value:
-                (Format.asprintf "`%a`%s" Shared_ast.Print.typ ty extra_doc)))
+      Some doc
     in
-    let label, detail, kind, documentation =
+    let open Format in
+    let signature, doc =
       match k with
-      | Module m ->
-        ModuleName.to_string m, "Module", CompletionItemKind.Module, None
-      | StdlibModule (_m, alias) -> alias, "Stdlib", Module, None
-      | Struct s -> StructName.base s, "Structure", Struct, None
-      | Enum e -> EnumName.base e, "Enumeration", Enum, None
-      | Constructor c ->
-        EnumConstructor.to_string c, "Constructor", Constructor, None
-      | Scope s -> ScopeName.base s, "Scope", Function, None
-      | Topdef { name; ty; extra_doc } ->
-        TopdefName.base name, "Function", Function, doc ?extra_doc ty
+      | Module _ -> None, None (* TODO: print module content *)
+      | StdlibModule _ -> None, None (* TODO: print module content *)
+      | Struct { name; fields } ->
+        ( Some (Type_printing.struct_code ~markdown:true locale (name, fields)),
+          extract_doc StructName.get_info name )
+      | Enum { name; constrs } ->
+        ( Some (Type_printing.enum_code ~markdown:true locale (name, constrs)),
+          extract_doc EnumName.get_info name )
+      | Constructor { constr; enum_name } ->
+        ( Some
+            (asprintf "```catala_code_%s@\n%a.%s@\n```"
+               (Type_printing.locale_s locale)
+               EnumName.format_shortpath enum_name
+               (EnumConstructor.to_string constr)),
+          extract_doc EnumConstructor.get_info constr )
+      | Scope { name; decl } ->
+        ( Some (Type_printing.sig_type ~markdown:true locale name decl.scope_sig),
+          extract_doc ScopeName.get_info name )
+      | Topdef { name; ty } ->
+        ( Some
+            (asprintf "```catala_code_%s@\n%s : %a@\n```"
+               (Type_printing.locale_s locale)
+               (TopdefName.base name)
+               (Type_printing.pp_typ locale)
+               ty),
+          extract_doc TopdefName.get_info name )
       | ScopeVar { name; ty } ->
-        ScopeVar.to_string name, "Variable", Variable, doc ty
+        ( Some
+            (asprintf "```catala_code_%s@\n%a@\n```"
+               (Type_printing.locale_s locale)
+               (Type_printing.pp_scope_var locale)
+               (name, ty)),
+          extract_doc ScopeVar.get_info name )
       | StructField { name; ty } ->
-        StructField.to_string name, "Field", Field, doc ty
-      | Keyword { lexeme; _ } -> lexeme, "Keyword", Keyword, None
+        ( Some
+            (asprintf "```catala_code_%s@\n%a@\n```"
+               (Type_printing.locale_s locale)
+               (Type_printing.pp_struct_field locale)
+               (name, ty)),
+          extract_doc StructField.get_info name )
+      | Keyword _ -> None, None
     in
+    let*? value =
+      match signature, doc with
+      | None, None -> None
+      | Some s, None | None, Some s -> Some s
+      | Some sigz, Some doc -> Some Format.(asprintf "%s@\n%s" sigz doc)
+    in
+    Some
+      (`MarkupContent (MarkupContent.create ~kind:MarkupKind.Markdown ~value))
+
+  let itemkind locale : t -> completion =
+   fun k ->
+    let label, detail, kind =
+      match k with
+      | Module m -> ModuleName.to_string m, "Module", CompletionItemKind.Module
+      | StdlibModule { alias; _ } -> alias, "Stdlib Module", Module
+      | Struct { name; _ } -> StructName.base name, "Structure", Struct
+      | Enum { name; _ } -> EnumName.base name, "Enumeration", Enum
+      | Constructor { constr; _ } ->
+        EnumConstructor.to_string constr, "Constructor", Constructor
+      | Scope { name; _ } -> ScopeName.base name, "Scope", Function
+      | Topdef { name; _ } -> TopdefName.base name, "Function", Function
+      | ScopeVar { name; _ } -> ScopeVar.to_string name, "Variable", Variable
+      | StructField { name; _ } -> StructField.to_string name, "Field", Field
+      | Keyword { lexeme; _ } -> lexeme, "Keyword", Keyword
+    in
+    let documentation = make_doc locale k in
     { label; detail; kind; documentation }
 
-  let to_completion : t -> Linol_lwt.CompletionItem.t =
+  let to_completion locale : t -> Linol_lwt.CompletionItem.t =
    fun k ->
-    let { label; detail; kind; documentation } = itemkind k in
+    let { label; detail; kind; documentation } = itemkind locale k in
     CompletionItem.create ~label ~detail ~kind ?documentation ()
 
   module Set = struct
@@ -266,11 +279,14 @@ module Kind = struct
       let compare l r =
         match l, r with
         | Module l, Module r -> ModuleName.compare l r
-        | StdlibModule (l, _), StdlibModule (r, _) -> ModuleName.compare l r
-        | Struct l, Struct r -> StructName.compare l r
-        | Enum l, Enum r -> EnumName.compare l r
-        | Constructor l, Constructor r -> EnumConstructor.compare l r
-        | Scope l, Scope r -> ScopeName.compare l r
+        | StdlibModule { name = l; _ }, StdlibModule { name = r; _ } ->
+          ModuleName.compare l r
+        | Struct { name = l; _ }, Struct { name = r; _ } ->
+          StructName.compare l r
+        | Enum { name = l; _ }, Enum { name = r; _ } -> EnumName.compare l r
+        | Constructor { constr = l; _ }, Constructor { constr = r; _ } ->
+          EnumConstructor.compare l r
+        | Scope { name = l; _ }, Scope { name = r; _ } -> ScopeName.compare l r
         | Topdef { name = l; _ }, Topdef { name = r; _ } ->
           TopdefName.compare l r
         | ScopeVar { name = l; _ }, ScopeVar { name = r; _ } ->
@@ -323,7 +339,7 @@ let lookup_modules ?prefix (prg : typed Scopelang.Ast.program) m =
           let alias =
             lookup_alias_name prg.program_lang (ModuleName.to_string m)
           in
-          Some (Kind.StdlibModule (m, alias)))
+          Some (Kind.StdlibModule { name = m; alias }))
     |> Kind.Set.of_seq
   in
   let nonstdlib_modules =
@@ -342,7 +358,11 @@ let lookup_scopes ?prefix ?modname (prg : typed Scopelang.Ast.program) m =
       |> function None -> ScopeName.Map.empty | Some scopes -> scopes)
   in
   ScopeName.Map.to_seq scopes
-  |> Seq.map (fun (s, _) -> Kind.Scope s)
+  |> Seq.map (fun (name, (decl, _)) ->
+      let name =
+        rename_alias_in_path prg.program_lang ScopeName.map_info name
+      in
+      Kind.Scope { name; decl })
   |> Kind.Set.of_seq
   |> update_all ?prefix m
 
@@ -362,7 +382,11 @@ let lookup_structs ?prefix ?modname (prg : typed Scopelang.Ast.program) m =
         prg.program_ctx.ctx_structs
   in
   StructName.Map.to_seq structs
-  |> Seq.map (fun (s, _) -> Kind.Struct s)
+  |> Seq.map (fun (name, fields) ->
+      let name =
+        rename_alias_in_path prg.program_lang StructName.map_info name
+      in
+      Kind.Struct { name; fields })
   |> Kind.Set.of_seq
   |> update_all ?prefix m
 
@@ -396,7 +420,9 @@ let lookup_enums ?prefix ?modname (prg : typed Scopelang.Ast.program) m =
         prg.program_ctx.ctx_enums
   in
   EnumName.Map.to_seq enums
-  |> Seq.map (fun (s, _) -> Kind.Enum s)
+  |> Seq.map (fun (name, constrs) ->
+      let name = rename_alias_in_path prg.program_lang EnumName.map_info name in
+      Kind.Enum { name; constrs })
   |> Kind.Set.of_seq
   |> update_all ?prefix m
 
@@ -408,32 +434,28 @@ let lookup_constructors ?prefix ?enum_name (prg : typed Scopelang.Ast.program) m
       Ident.Map.fold
         (fun _id enum_map acc ->
           EnumName.Map.to_seq enum_map
-          |> Seq.map snd
-          |> fun sq -> EnumConstructor.Set.add_seq sq acc)
-        prg.program_ctx.ctx_enum_constrs EnumConstructor.Set.empty
+          |> Seq.map (fun (a, b) -> b, a)
+          |> fun sq -> EnumConstructor.Map.add_seq sq acc)
+        prg.program_ctx.ctx_enum_constrs EnumConstructor.Map.empty
     | Some e -> (
       let enum_opt = EnumName.Map.find_opt e prg.program_ctx.ctx_enums in
       match enum_opt with
-      | None -> EnumConstructor.Set.empty
+      | None -> EnumConstructor.Map.empty
       | Some cs ->
         EnumConstructor.Map.to_seq cs
-        |> Seq.map fst
-        |> EnumConstructor.Set.of_seq)
+        |> Seq.map (fun (c, _) -> c, e)
+        |> EnumConstructor.Map.of_seq)
   in
-  EnumConstructor.Set.to_seq constructors
-  |> Seq.map (fun s -> Kind.Constructor s)
+  EnumConstructor.Map.to_seq constructors
+  |> Seq.map (fun (constr, enum_name) ->
+      let enum_name =
+        rename_alias_in_path prg.program_lang EnumName.map_info enum_name
+      in
+      Kind.Constructor { constr; enum_name })
   |> Kind.Set.of_seq
   |> update_all ?prefix m
 
 let lookup_topdefs ?prefix ?modname (prg : typed Scopelang.Ast.program) m =
-  let extract_doc td =
-    TopdefName.get_info td
-    |> Mark.get
-    |> Pos.attrs
-    |> List.filter_map (function Doc (d, _) -> Some d | _ -> None)
-    |> String.concat "\n"
-    |> Option.some
-  in
   let topdefs =
     match modname with
     | None ->
@@ -441,8 +463,7 @@ let lookup_topdefs ?prefix ?modname (prg : typed Scopelang.Ast.program) m =
          insert the required module *)
       TopdefName.Map.filter_map
         (fun td (typ, _vis) ->
-          let extra_doc = extract_doc td in
-          if TopdefName.path td = [] then Some (typ, extra_doc) else None)
+          if TopdefName.path td = [] then Some typ else None)
         prg.program_ctx.ctx_topdefs
     | Some m ->
       TopdefName.Map.filter_map
@@ -452,13 +473,15 @@ let lookup_topdefs ?prefix ?modname (prg : typed Scopelang.Ast.program) m =
             |> List.rev
             |> function [] -> None | h :: _ -> Some h
           in
-          let extra_doc = extract_doc td in
-          if ModuleName.equal m m' then Some (typ, extra_doc) else None)
+          if ModuleName.equal m m' then Some typ else None)
         prg.program_ctx.ctx_topdefs
   in
   TopdefName.Map.to_seq topdefs
-  |> Seq.map (fun (name, (ty, extra_doc)) ->
-      Kind.Topdef { name; ty; extra_doc })
+  |> Seq.map (fun (name, (ty : Shared_ast.typ)) ->
+      let name =
+        rename_alias_in_path prg.program_lang TopdefName.map_info name
+      in
+      Kind.Topdef { name; ty })
   |> Kind.Set.of_seq
   |> update_all ?prefix m
 
@@ -466,13 +489,8 @@ let lookup_scopevars ?prefix (prg : typed Scopelang.Ast.program) m =
   ScopeName.Map.to_seq prg.program_scopes
   |> Seq.map (fun (_, sdecl) ->
       ScopeVar.Map.to_seq (Mark.remove sdecl).Scopelang.Ast.scope_sig
-      |> Seq.concat_map (fun (name, (ty : Scopelang.Ast.scope_var_ty)) ->
-          List.to_seq
-          @@ List.sort_uniq compare
-               [
-                 Kind.ScopeVar { name; ty = ty.svar_in_ty };
-                 Kind.ScopeVar { name; ty = ty.svar_out_ty };
-               ]))
+      |> Seq.map (fun (name, (ty : Scopelang.Ast.scope_var_ty)) ->
+          Kind.ScopeVar { name; ty }))
   |> Seq.concat
   |> Kind.Set.of_seq
   |> update_all ?prefix m
@@ -485,22 +503,31 @@ let follow_ups ?prefix prg (kind : Kind.t) m =
   match kind, prefix with
   | _, Some (FullUident _ | FullLident _) -> (* Not a partial prefix *) m
   | Enum _, Some (PartialLident _) -> m
-  | (Module modname | StdlibModule (modname, _)), None ->
+  | (Module modname | StdlibModule { name = modname; _ }), None ->
     m
     |> lookup_topdefs ?prefix ~modname prg
     |> lookup_structs ?prefix ~modname prg
     |> lookup_enums ?prefix ~modname prg
     |> lookup_scopes ?prefix ~modname prg
-  | (Module modname | StdlibModule (modname, _)), Some (PartialUident _) ->
+  | ( (Module modname | StdlibModule { name = modname; _ }),
+      Some (PartialUident _) ) ->
     m
     |> lookup_structs ?prefix ~modname prg
     |> lookup_enums ?prefix ~modname prg
     |> lookup_scopes ?prefix ~modname prg
-  | (Module modname | StdlibModule (modname, _)), Some (PartialLident _) ->
+  | ( (Module modname | StdlibModule { name = modname; _ }),
+      Some (PartialLident _) ) ->
     m |> lookup_topdefs ?prefix ~modname prg
-  | Enum enum_name, _ -> lookup_constructors ?prefix ~enum_name prg m
-  | ScopeVar { ty = TStruct structname, _; _ }, _
-  | ScopeVar { ty = TDefault (TStruct structname, _), _; _ }, _ ->
+  | Enum { name = enum_name; _ }, _ ->
+    lookup_constructors ?prefix ~enum_name prg m
+  | ScopeVar { ty = { svar_out_ty = TStruct structname, _; _ }; _ }, _
+  | ScopeVar { ty = { svar_in_ty = TStruct structname, _; _ }; _ }, _
+  | ( ScopeVar
+        { ty = { svar_out_ty = TDefault (TStruct structname, _), _; _ }; _ },
+      _ )
+  | ( ScopeVar
+        { ty = { svar_in_ty = TDefault (TStruct structname, _), _; _ }; _ },
+      _ ) ->
     lookup_struct_fields ?prefix ~structname prg m
   | Struct _, _
   | Constructor _, _
@@ -562,7 +589,7 @@ let lident_dot_prefix lident ?prefix_tok prg =
     (fun _qual s m -> Kind.Set.fold (fun k m -> follow_ups ?prefix prg k m) s m)
     map CompletionMap.empty
 
-let to_completions completion_map =
+let to_completions locale completion_map =
   CompletionMap.map
     (fun kinds ->
       (* Scope always have a associated struct => filter it out to prevent
@@ -573,7 +600,7 @@ let to_completions completion_map =
     completion_map
   |> CompletionMap.bindings
   |> List.concat_map (fun (_, sk) ->
-      Kind.Set.elements sk |> List.map Kind.to_completion)
+      Kind.Set.elements sk |> List.map (Kind.to_completion locale))
   |> Utils.option_of_list
 
 let lookup_completions (doc : document_state) ~doc_content pos =
@@ -591,6 +618,9 @@ let lookup_completions (doc : document_state) ~doc_content pos =
       let rc = rp.Lexing.pos_cnum - rp.Lexing.pos_bol + 1 in
       pos.Position.character + 1 <= rc
   in
+  let*? last_valid_result = doc.last_valid_result in
+  let prg = last_valid_result.prg in
+  let to_completions = to_completions prg.program_lang in
   let open Tokens in
   let r =
     match rev_tokens with
@@ -598,33 +628,20 @@ let lookup_completions (doc : document_state) ~doc_content pos =
       :: (_, DOT, _)
       :: (_, UIDENT qualif, _)
       :: _ ->
-      let*? last_valid_result = doc.last_valid_result in
-      let prg = last_valid_result.prg in
       let completion_map = uident_dot_prefix qualif ~prefix_tok:tok prg in
       to_completions completion_map
     | (_, DOT, _) :: (_, UIDENT qualif, _) :: _ ->
-      let*? last_valid_result = doc.last_valid_result in
-      let prg = last_valid_result.prg in
       let completions_map = uident_dot_prefix qualif prg in
       to_completions completions_map
     | (_, DOT, _) :: (_, LIDENT qualif, _) :: _ ->
-      let*? last_valid_result = doc.last_valid_result in
-      let prg = last_valid_result.prg in
       lident_dot_prefix qualif prg |> to_completions
     | (_, (LIDENT _ as prefix_tok), _)
       :: (_, DOT, _)
       :: (_, LIDENT qualif, _)
       :: _ ->
-      let*? last_valid_result = doc.last_valid_result in
-      let prg = last_valid_result.prg in
       lident_dot_prefix ~prefix_tok qualif prg |> to_completions
-    | (_, (UIDENT _s as tok), _) :: _ ->
-      let*? last_valid_result = doc.last_valid_result in
-      let prg = last_valid_result.prg in
-      single_uident tok prg |> to_completions
+    | (_, (UIDENT _s as tok), _) :: _ -> single_uident tok prg |> to_completions
     | (_, (LIDENT _s as tok), _) :: _ when on_token ->
-      let*? last_valid_result = doc.last_valid_result in
-      let prg = last_valid_result.prg in
       single_lident tok prg |> to_completions
     | _ -> None
   in

--- a/server/src/doc_completion.ml
+++ b/server/src/doc_completion.ml
@@ -750,7 +750,20 @@ let lookup_completions (doc : document_state) ~doc_content pos =
       let rc = rp.Lexing.pos_cnum - rp.Lexing.pos_bol + 1 in
       pos.Position.character + 1 <= rc
   in
-  let*? last_valid_result = doc.last_valid_result in
+  let*? last_valid_result =
+    match doc.last_valid_result, doc.last_result with
+    | Some x, _ -> Some x
+    | None, Some (Partial (_, r)) ->
+      Log.debug (fun m ->
+          m "Using partial result for completion of document %a" Doc_id.format
+            doc.document_id);
+      Some r
+    | _ ->
+      Log.debug (fun m ->
+          m "No exploitable result for completion of document %a" Doc_id.format
+            doc.document_id);
+      None
+  in
   let prg = last_valid_result.prg in
   let to_completions = to_completions prg.program_lang in
   let open Tokens in

--- a/server/src/doc_completion.ml
+++ b/server/src/doc_completion.ml
@@ -149,7 +149,12 @@ module Kind = struct
     | Constructor of { constr : EnumConstructor.t; enum_name : EnumName.t }
     | Scope of { name : ScopeName.t; decl : typed Scopelang.Ast.scope_decl }
     | Topdef of { name : TopdefName.t; ty : Shared_ast.typ }
-    | ScopeVar of { name : ScopeVar.t; ty : Scopelang.Ast.scope_var_ty }
+    | ScopeVar of {
+        name : ScopeVar.t;
+        scope : ScopeName.t;
+        states : string list option;
+        ty : Scopelang.Ast.scope_var_ty;
+      }
     | StructField of { name : StructField.t; ty : Shared_ast.typ }
     | Keyword of { lexeme : string; token : Tokens.token }
 
@@ -223,12 +228,25 @@ module Kind = struct
                (Type_printing.pp_typ locale)
                ty),
           extract_doc TopdefName.get_info name )
-      | ScopeVar { name; ty } ->
+      | ScopeVar { name; scope = _; states = None; ty } ->
         ( Some
-            (asprintf "```catala_code_%s@\n%a@\n```"
+            (asprintf "```catala_code_%s@\n%a@]@\n```"
                (Type_printing.locale_s locale)
-               (Type_printing.pp_scope_var locale)
+               (Type_printing.pp_scope_var ~skip_internals:false locale)
                (name, ty)),
+          extract_doc ScopeVar.get_info name )
+      | ScopeVar { name; scope = _; states = Some states; ty } ->
+        ( Some
+            (asprintf "```catala_code_%s@\n@[<v 2>%a@ %a@]@\n```"
+               (Type_printing.locale_s locale)
+               (Type_printing.pp_scope_var ~skip_internals:false locale)
+               (name, ty)
+               Format.(
+                 pp_print_list ~pp_sep:pp_print_space (fun fmt state ->
+                     fprintf fmt "%s %s"
+                       (Type_printing.svar_state_s locale)
+                       state))
+               states),
           extract_doc ScopeVar.get_info name )
       | StructField { name; ty } ->
         ( Some
@@ -260,7 +278,10 @@ module Kind = struct
         EnumConstructor.to_string constr, "Constructor", Constructor
       | Scope { name; _ } -> ScopeName.base name, "Scope", Function
       | Topdef { name; _ } -> TopdefName.base name, "Function", Function
-      | ScopeVar { name; _ } -> ScopeVar.to_string name, "Variable", Variable
+      | ScopeVar { name; scope; _ } ->
+        ( ScopeVar.to_string name,
+          Format.sprintf "Scope Variable (%s)" (ScopeName.base scope),
+          Variable )
       | StructField { name; _ } -> StructField.to_string name, "Field", Field
       | Keyword { lexeme; _ } -> lexeme, "Keyword", Keyword
     in
@@ -289,8 +310,14 @@ module Kind = struct
         | Scope { name = l; _ }, Scope { name = r; _ } -> ScopeName.compare l r
         | Topdef { name = l; _ }, Topdef { name = r; _ } ->
           TopdefName.compare l r
-        | ScopeVar { name = l; _ }, ScopeVar { name = r; _ } ->
-          ScopeVar.compare l r
+        | ( ScopeVar { name = l; scope = sl; _ },
+            ScopeVar { name = r; scope = sr; _ } ) ->
+          let cmp = ScopeName.compare sl sr in
+          if cmp <> 0 then cmp
+          else
+            String.compare
+              (ScopeVar.get_info l |> Mark.remove)
+              (ScopeVar.get_info r |> Mark.remove)
         | l, r -> compare l r
     end)
   end
@@ -486,13 +513,45 @@ let lookup_topdefs ?prefix ?modname (prg : typed Scopelang.Ast.program) m =
   |> update_all ?prefix m
 
 let lookup_scopevars ?prefix (prg : typed Scopelang.Ast.program) m =
-  ScopeName.Map.to_seq prg.program_scopes
-  |> Seq.map (fun (_, sdecl) ->
-      ScopeVar.Map.to_seq (Mark.remove sdecl).Scopelang.Ast.scope_sig
-      |> Seq.map (fun (name, (ty : Scopelang.Ast.scope_var_ty)) ->
-          Kind.ScopeVar { name; ty }))
-  |> Seq.concat
-  |> Kind.Set.of_seq
+  let all_scopes_vars : Kind.t list Seq.t =
+    ScopeName.Map.to_seq prg.program_scopes
+    |> Seq.map (fun (scope, sdecl) ->
+        let all_scope_vars =
+          ScopeVar.Map.to_seq (Mark.remove sdecl).Scopelang.Ast.scope_sig
+          |> Seq.filter_map (fun (name, (ty : Scopelang.Ast.scope_var_ty)) ->
+              let var_s, _pos = ScopeVar.get_info name in
+              match String.split_on_char '#' var_s with
+              | [_] ->
+                Some (var_s, Kind.ScopeVar { name; scope; states = None; ty })
+              | [ident; state] ->
+                let name = ScopeVar.map_info (fun _ -> ident, Pos.void) name in
+                Some
+                  ( ident,
+                    Kind.ScopeVar { name; scope; states = Some [state]; ty } )
+              | _ -> None (* shouldn't happen *))
+        in
+        Seq.fold_left
+          (fun m (name, k) ->
+            let merge k k' =
+              match k, k' with
+              | (Kind.ScopeVar _ as x), Kind.ScopeVar { states = None; _ }
+              | Kind.ScopeVar { states = None; _ }, (Kind.ScopeVar _ as x) ->
+                Some x
+              | ( Kind.ScopeVar ({ states = Some l; _ } as x),
+                  Kind.ScopeVar { states = Some r; _ } ) ->
+                Some (Kind.ScopeVar { x with states = Some (l @ r) })
+              | _ -> None
+            in
+            String.Map.update name
+              (function None -> Some k | Some k' -> merge k k')
+              m)
+          String.Map.empty all_scope_vars
+        |> String.Map.values)
+  in
+  all_scopes_vars
+  |> List.of_seq
+  |> List.concat
+  |> Kind.Set.of_list
   |> update_all ?prefix m
 
 let find_qualifiers prg uident =
@@ -624,26 +683,24 @@ let lookup_completions (doc : document_state) ~doc_content pos =
   let open Tokens in
   let r =
     match rev_tokens with
+    | (_, (UIDENT _s as tok), _) :: (_, OF, _) :: (_, OUTPUT, _) :: _ ->
+      lookup_scopes prg ~prefix:(partial_prefix tok) CompletionMap.empty
+    | (_, OF, _) :: (_, OUTPUT, _) :: _ -> lookup_scopes prg CompletionMap.empty
     | (_, ((UIDENT _ | LIDENT _) as tok), _) (* <= curr token *)
       :: (_, DOT, _)
       :: (_, UIDENT qualif, _)
       :: _ ->
-      let completion_map = uident_dot_prefix qualif ~prefix_tok:tok prg in
-      to_completions completion_map
-    | (_, DOT, _) :: (_, UIDENT qualif, _) :: _ ->
-      let completions_map = uident_dot_prefix qualif prg in
-      to_completions completions_map
-    | (_, DOT, _) :: (_, LIDENT qualif, _) :: _ ->
-      lident_dot_prefix qualif prg |> to_completions
+      uident_dot_prefix qualif ~prefix_tok:tok prg
+    | (_, DOT, _) :: (_, UIDENT qualif, _) :: _ -> uident_dot_prefix qualif prg
+    | (_, DOT, _) :: (_, LIDENT qualif, _) :: _ -> lident_dot_prefix qualif prg
     | (_, (LIDENT _ as prefix_tok), _)
       :: (_, DOT, _)
       :: (_, LIDENT qualif, _)
       :: _ ->
-      lident_dot_prefix ~prefix_tok qualif prg |> to_completions
-    | (_, (UIDENT _s as tok), _) :: _ -> single_uident tok prg |> to_completions
-    | (_, (LIDENT _s as tok), _) :: _ when on_token ->
-      single_lident tok prg |> to_completions
-    | _ -> None
+      lident_dot_prefix ~prefix_tok qualif prg
+    | (_, (UIDENT _s as tok), _) :: _ -> single_uident tok prg
+    | (_, (LIDENT _s as tok), _) :: _ when on_token -> single_lident tok prg
+    | _ -> CompletionMap.empty
   in
   (* Log.debug (fun m -> *)
   (*     m "@[<v 2>Full completion candidates:@ %a@]" *)
@@ -652,7 +709,7 @@ let lookup_completions (doc : document_state) ~doc_content pos =
   (*            pp_print_list (fun fmt { CompletionItem.label; _ } -> *)
   (*                Format.pp_print_string fmt label))) *)
   (*       r); *)
-  r
+  to_completions r
 
 let lookup_completions
     (doc : document_state)

--- a/server/src/doc_completion.mli
+++ b/server/src/doc_completion.mli
@@ -1,0 +1,27 @@
+(* This file is part of the Catala compiler, a specification language for tax
+   and social benefits computation rules. Copyright (C) 2026 Inria, contributor:
+   Vincent Botbol <vincent.botbol@inria.fr>
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License. *)
+(****************************************************************)
+
+open Server_state
+open Linol_lwt
+open Server_types
+
+val lookup_completions :
+  document_state ->
+  doc_content:string ->
+  Position.t ->
+  diagnostic Server_types.Range.Map.t Doc_id.Map.t ->
+  CompletionItem.t list option

--- a/server/src/doc_queries.ml
+++ b/server/src/doc_queries.ml
@@ -114,10 +114,10 @@ let get_hover_type ?(markdown = false) f p =
     try Jump_table.Ord_lookup.max_elt lookup_s with _ -> assert false
   in
   if markdown then
-    let md = Type_printing.typ_to_markdown ~prg f.locale kind in
+    let md = Type_printing.typ_to_markdown prg f.locale kind in
     Some (Linol_lwt.Hover.create ~range ~contents:(`MarkupContent md) ())
   else
-    let md = Type_printing.typ_to_raw_string ~prg f.locale kind in
+    let md = Type_printing.typ_to_raw_string prg f.locale kind in
     Some (Linol_lwt.Hover.create ~range ~contents:(`MarkedString md) ())
 
 let lookup_type_declaration f p =

--- a/server/src/doc_queries.ml
+++ b/server/src/doc_queries.ml
@@ -32,8 +32,9 @@ let lookup_completions (doc : document_state) ~doc_content pos diagnostics =
 let all_symbols_as_warning (doc_id : Doc_id.t) processing_result =
   let diags : (Doc_id.doc_id * Diagnostic.t list) list =
     match processing_result with
-    | None -> []
-    | Some { jump_table = (lazy { variables; lookup_table }); _ } ->
+    | Skipped | Faulty _ -> []
+    | Partial (_, { jump_table = (lazy { variables; lookup_table }); _ })
+    | Valid { jump_table = (lazy { variables; lookup_table }); _ } ->
       (* Displays the full position map in logs *)
       (* Log.info (fun m -> m "%a@." Jump_table.PMap.pp variables); *)
       (* Generates warning diagnostic for each symbol *)

--- a/server/src/doc_queries.ml
+++ b/server/src/doc_queries.ml
@@ -39,9 +39,23 @@ let lookup_suggestions doc_id diagnostics range =
     | None | Some [] -> None
     | Some suggs -> Some (range, suggs))
 
-let lookup_suggestions_by_pos doc_id diagnostics pos =
-  let range = { Linol_lwt.Range.start = pos; end_ = pos } in
+let lookup_suggestions_by_pos doc_id diagnostics range =
+  let open Linol_lwt in
   lookup_suggestions doc_id diagnostics range
+  |> function
+  | None -> None
+  | Some (range, completions) ->
+    Some
+      (List.map
+         (fun sugg ->
+           let textEdit = `TextEdit (TextEdit.create ~range ~newText:sugg) in
+           CompletionItem.create ~kind:Keyword ~label:sugg ~textEdit ())
+         completions)
+
+let lookup_completions (doc : document_state) ~doc_content pos diagnostics =
+  Doc_completion.lookup_completions
+    (doc : document_state)
+    ~doc_content pos diagnostics
 
 (* This is use for debugging: call this function in all_diagnostics to underline
    all processed symbols in LSP. Useful to determine which expression wasn't

--- a/server/src/doc_queries.ml
+++ b/server/src/doc_queries.ml
@@ -30,47 +30,68 @@ let lookup_completions (doc : document_state) ~doc_content pos diagnostics =
    all processed symbols in LSP. Useful to determine which expression wasn't
    properly handled. *)
 let all_symbols_as_warning (doc_id : Doc_id.t) processing_result =
-  match processing_result with
-  | None -> []
-  | Some { jump_table = (lazy { variables; lookup_table }); _ } ->
-    (* Displays the full position map in logs *)
-    (* Log.info (fun m -> m "%a@." Jump_table.PMap.pp variables); *)
-    (* Generates warning diagnostic for each symbol *)
-    [
-      ( doc_id,
-        Jump_table.LTable.bindings lookup_table
-        |> List.map snd
-        |> List.concat_map
-             (fun { Jump_table.declaration; definitions; usages; types } ->
-               let build r =
-                 Diagnostic.diag_r Warning (range_of_pos r) (`String "abc")
-               in
-               let declaration = Option.map (fun x -> [x]) declaration in
-               [declaration; definitions; usages; types]
-               |> List.filter_map (function
-                 | None -> None
-                 | Some r -> (
-                   List.filter
-                     (fun r -> Catala_utils.Pos.get_file r = (doc_id :> File.t))
-                     r
-                   |> function [] -> None | r -> Some r))
-               |> List.concat
-               |> List.map build) );
-    ]
-    @ [
+  let diags : (Doc_id.doc_id * Diagnostic.t list) list =
+    match processing_result with
+    | None -> []
+    | Some { jump_table = (lazy { variables; lookup_table }); _ } ->
+      (* Displays the full position map in logs *)
+      (* Log.info (fun m -> m "%a@." Jump_table.PMap.pp variables); *)
+      (* Generates warning diagnostic for each symbol *)
+      [
         ( doc_id,
-          Jump_table.PMap.fold_on_file doc_id
-            (fun r v acc ->
-              let msg =
-                Format.asprintf "%a : @[<h>%a@]"
-                  Format.(
-                    pp_print_list ~pp_sep:pp_print_space Jump_table.pp_var)
-                  (Jump_table.PMap.DS.elements v)
-                  Catala_utils.Pos.format_loc_text r
-              in
-              Diagnostic.diag_r Warning (range_of_pos r) (`String msg) :: acc)
-            variables [] );
+          Jump_table.LTable.bindings lookup_table
+          |> List.map snd
+          |> List.concat_map
+               (fun { Jump_table.declaration; definitions; usages; types } ->
+                 let build r =
+                   Diagnostic.diag_r Warning (range_of_pos r) (`String "abc")
+                 in
+                 let declaration = Option.map (fun x -> [x]) declaration in
+                 [declaration; definitions; usages; types]
+                 |> List.filter_map (function
+                   | None -> None
+                   | Some r -> (
+                     List.filter
+                       (fun r ->
+                         Catala_utils.Pos.get_file r = (doc_id :> File.t))
+                       r
+                     |> function [] -> None | r -> Some r))
+                 |> List.concat
+                 |> List.map build) );
       ]
+      @ [
+          ( doc_id,
+            Jump_table.PMap.fold_on_file doc_id
+              (fun r v acc ->
+                let msg =
+                  Format.asprintf "%a : @[<h>%a@]"
+                    Format.(
+                      pp_print_list ~pp_sep:pp_print_space Jump_table.pp_var)
+                    (Jump_table.PMap.DS.elements v)
+                    Catala_utils.Pos.format_loc_text r
+                in
+                Diagnostic.diag_r Warning (range_of_pos r) (`String msg) :: acc)
+              variables [] );
+        ]
+  in
+  let m : diagnostic Range.Map.t Doc_id.Map.t =
+    List.fold_left
+      (fun m (doc_id, diags) ->
+        let diags =
+          List.map
+            (fun (diag : Diagnostic.t) ->
+              ( diag.range,
+                ({ range = diag.range; lsp_error = None; diag } : diagnostic) ))
+            diags
+        in
+        Doc_id.Map.update doc_id
+          (function
+            | None -> Some (Range.Map.of_list diags)
+            | Some s -> Some (Range.Map.add_seq (List.to_seq diags) s))
+          m)
+      Doc_id.Map.empty diags
+  in
+  m
 
 let of_position pos = Catala_utils.Pos.get_file pos, Utils.range_of_pos pos
 

--- a/server/src/doc_queries.ml
+++ b/server/src/doc_queries.ml
@@ -21,37 +21,6 @@ open Catala_utils
 open Utils
 open Shared_ast
 
-let pp_range fmt { Linol_lwt.Range.start; end_ } =
-  let open Format in
-  let pp_pos fmt { Linol_lwt.Position.line; character } =
-    fprintf fmt "l:%d, c:%d" line character
-  in
-  fprintf fmt "start:(%a), end:(%a)" pp_pos start pp_pos end_
-
-let lookup_suggestions doc_id diagnostics range =
-  let*? rmap = Doc_id.Map.find_opt doc_id diagnostics in
-  Range.Map.find_opt range rmap
-  |> function
-  | None -> None
-  | Some { range; lsp_error; _ } -> (
-    let*? lsp_error = lsp_error in
-    match lsp_error.suggestion with
-    | None | Some [] -> None
-    | Some suggs -> Some (range, suggs))
-
-let lookup_suggestions_by_pos doc_id diagnostics range =
-  let open Linol_lwt in
-  lookup_suggestions doc_id diagnostics range
-  |> function
-  | None -> None
-  | Some (range, completions) ->
-    Some
-      (List.map
-         (fun sugg ->
-           let textEdit = `TextEdit (TextEdit.create ~range ~newText:sugg) in
-           CompletionItem.create ~kind:Keyword ~label:sugg ~textEdit ())
-         completions)
-
 let lookup_completions (doc : document_state) ~doc_content pos diagnostics =
   Doc_completion.lookup_completions
     (doc : document_state)

--- a/server/src/doc_queries.ml
+++ b/server/src/doc_queries.ml
@@ -158,6 +158,32 @@ let lookup_type_declaration f p =
     Some (of_position @@ Mark.get (ScopeName.get_info scope_decl_name))
   | Expr _ | Type _ -> None
 
+let lookup_occurences f p : Range.Set.t Doc_id.Map.t option =
+  let p = Utils.(lsp_range p p |> pos_of_range (f.document_id :> File.t)) in
+  let*? { jump_table = (lazy jt); _ } = f.last_valid_result in
+  let occurences = Jump_table.lookup jt p in
+  let m =
+    List.fold_left
+      (fun m { Jump_table.declaration; definitions; usages; types } ->
+        let all_ranges =
+          Option.to_list declaration
+          @ (Option.to_list definitions |> List.flatten)
+          @ (Option.to_list usages |> List.flatten)
+          @ (Option.to_list types |> List.flatten)
+          |> List.map (fun p -> Doc_id.of_catala_pos p, Utils.range_of_pos p)
+        in
+        List.fold_left
+          (fun m (doc_id, r) ->
+            Doc_id.Map.update doc_id
+              (function
+                | None -> Some (Range.Set.singleton r)
+                | Some s -> Some (Range.Set.add r s))
+              m)
+          m all_ranges)
+      Doc_id.Map.empty occurences
+  in
+  if Doc_id.Map.is_empty m then None else Some m
+
 let lookup_document_symbols file =
   let*?! { jump_table = (lazy jt); _ } = file.last_valid_result, [] in
   Jump_table.PMap.fold_on_file file.document_id

--- a/server/src/doc_queries.mli
+++ b/server/src/doc_queries.mli
@@ -4,11 +4,6 @@ open Server_types
 open Server_state
 open Catala_utils
 
-val pp_range : Format.formatter -> Range.t -> unit
-
-val lookup_suggestions :
-  Doc_id.t -> diagnostics -> Range.t -> (Range.t * string list) option
-
 val lookup_completions :
   document_state ->
   doc_content:string ->

--- a/server/src/doc_queries.mli
+++ b/server/src/doc_queries.mli
@@ -47,6 +47,9 @@ val lookup_usages :
   Linol_lwt.Position.t ->
   (string * Range.t) list option
 
+val lookup_occurences :
+  document_state -> Linol_lwt.Position.t -> Range.Set.t Doc_id.Map.t option
+
 val get_hover_type :
   ?markdown:bool ->
   document_state ->

--- a/server/src/doc_queries.mli
+++ b/server/src/doc_queries.mli
@@ -9,11 +9,12 @@ val pp_range : Format.formatter -> Range.t -> unit
 val lookup_suggestions :
   Doc_id.t -> diagnostics -> Range.t -> (Range.t * string list) option
 
-val lookup_suggestions_by_pos :
-  Doc_id.t ->
-  diagnostics ->
+val lookup_completions :
+  document_state ->
+  doc_content:string ->
   Linol_lwt.Position.t ->
-  (Range.t * string list) option
+  diagnostics ->
+  Linol_lwt.CompletionItem.t list option
 
 val all_symbols_as_warning :
   Doc_id.doc_id ->

--- a/server/src/doc_queries.mli
+++ b/server/src/doc_queries.mli
@@ -14,7 +14,7 @@ val lookup_completions :
 val all_symbols_as_warning :
   Doc_id.doc_id ->
   processing_result option ->
-  (Doc_id.doc_id * Diagnostic.t list) list
+  diagnostic Range.Map.t Doc_id.Map.t
 
 val of_position : Pos.t -> string * Range.t
 

--- a/server/src/doc_queries.mli
+++ b/server/src/doc_queries.mli
@@ -12,9 +12,7 @@ val lookup_completions :
   Linol_lwt.CompletionItem.t list option
 
 val all_symbols_as_warning :
-  Doc_id.doc_id ->
-  processing_result option ->
-  diagnostic Range.Map.t Doc_id.Map.t
+  Doc_id.doc_id -> processing_result -> diagnostic Range.Map.t Doc_id.Map.t
 
 val of_position : Pos.t -> string * Range.t
 

--- a/server/src/document_processing.ml
+++ b/server/src/document_processing.ml
@@ -53,6 +53,165 @@ let module_usage_error ({ mod_use_name; _ } : Surface.Ast.module_use) =
     suggestion = None;
   }
 
+let protect ~on_error f =
+  try Ok (f ())
+  with e -> (
+    let e = match e with Fun.Finally_raised e -> e | e -> e in
+    match e with
+    | Catala_utils.Message.CompilerError er -> Error [er]
+    | Catala_utils.Message.CompilerErrors er_and_bt_l ->
+      Error (List.map fst er_and_bt_l)
+    | Failed_to_load_interface mod_use ->
+      let lsp_err = module_usage_error mod_use in
+      on_error lsp_err;
+      Error []
+    | e ->
+      on_error
+        {
+          Message.kind = Generic;
+          message =
+            (fun fmt ->
+              Format.fprintf fmt
+                "Generic exception while processing document: %s"
+                (Printexc.to_string e));
+          pos = None;
+          suggestion = None;
+        };
+      Error
+        [
+          Format.ksprintf Message.Content.of_string "Generic exception: %s"
+            (Printexc.to_string e);
+        ])
+
+let process_pending_errors ~on_error () =
+  protect ~on_error Message.report_delayed_errors_if_any
+  |> Result.map_error (fun _ -> ())
+
+let lsp_errors_to_diag doc_id errors =
+  List.fold_left
+    (fun doc_map (err : Catala_utils.Message.lsp_error) ->
+      let uri, range =
+        match err.pos, err.kind with
+        | None, _ -> doc_id, dummy_range
+        | Some pos, Lexing ->
+          Doc_id.of_catala_pos pos, unclosed_range_of_pos pos
+        | Some pos, _ -> Doc_id.of_catala_pos pos, range_of_pos pos
+      in
+      let diag =
+        { range; lsp_error = Some err; diag = to_diagnostic range err }
+      in
+      Doc_id.Map.update uri
+        (function
+          | None -> Some (Range.Map.singleton range diag)
+          | Some x -> Some (Range.Map.add range diag x))
+        doc_map)
+    (Doc_id.Map.singleton doc_id Range.Map.empty)
+    errors
+
+let surface_to_scopelang
+    ~on_error
+    ~get_errors
+    ?resolve_included_file
+    (doc_id : Doc_id.t)
+    options
+    project
+    k : Server_state.processing_result =
+  let open Projects in
+  let handle = function
+    | Ok r -> r
+    | Error _errs ->
+      Server_state.Faulty (lsp_errors_to_diag doc_id (get_errors ()))
+  in
+  handle
+  @@ protect ~on_error
+  @@ fun () ->
+  (* Resets the lexing context to a fresh one *)
+  Surface.Lexer_common.context := Law;
+  let surface =
+    Surface.Parser_driver.parse_top_level_file ?resolve_included_file
+      options.Global.input_src
+  in
+  match surface.Surface.Ast.program_module with
+  | Some { module_external = true; _ } ->
+    (* If the module is external, we skip it as the translation from desugared
+       would trigger an error *)
+    Log.debug (fun m -> m "skipping external module interface");
+    Server_state.Skipped
+  | _ -> (
+    let root_dir, clerk_config =
+      match project.project_kind with
+      | Clerk { clerk_root_dir; clerk_config } -> clerk_root_dir, clerk_config
+      | No_clerk -> project.project_dir, Clerk_config.default_config
+    in
+    let includes = List.map Global.raw_file clerk_config.global.include_dirs in
+    let mod_uses, modules =
+      let check stdlib k =
+        if File.exists stdlib then
+          Driver.load_modules options
+            ~stdlib:(Some (Global.raw_file stdlib))
+            includes surface
+        else k ()
+      in
+      let build_stdlib_path =
+        File.(root_dir / clerk_config.global.build_dir / "libcatala")
+      in
+      check build_stdlib_path
+      @@ fun () ->
+      Log.debug (fun m -> m "Stdlib not found - calling `clerk start`");
+      let _ = File.process_out "clerk" ["start"] in
+      check build_stdlib_path
+      @@ fun () ->
+      try
+        Driver.load_modules options
+          ~stdlib:(Some (Global.raw_file build_stdlib_path))
+          includes surface
+      with e ->
+        on_error
+          {
+            Message.kind = Generic;
+            message =
+              (fun fmt ->
+                Format.fprintf fmt
+                  "Did not find the Catala stdlib path, please build your \
+                   project");
+            pos = Some (Pos.from_info (doc_id :> string) 1 1 1 1);
+            suggestion = None;
+          };
+        raise e
+    in
+    let ctx =
+      Desugared.Name_resolution.form_context (surface, mod_uses) modules
+    in
+    let modules_content : Surface.Ast.module_content Uid.Module.Map.t =
+      Uid.Module.Map.map (fun elt -> fst elt) modules
+    in
+    let ctx, modules_contents = ctx, modules_content in
+    let prg =
+      Desugared.From_surface.translate_program ctx modules_contents surface
+    in
+    let prg = Desugared.Disambiguate.program prg in
+    let () = Desugared.Linting.lint_program prg in
+    let exceptions_graphs =
+      Scopelang.From_desugared.build_exceptions_graph prg
+    in
+    let prg =
+      Scopelang.From_desugared.translate_program prg exceptions_graphs
+      |> Scopelang.Ast.type_program
+    in
+    let jump_table =
+      lazy
+        (Jump_table.populate options.input_src ctx modules_contents surface prg)
+    in
+    let used_modules : ModuleName.t File.Map.t =
+      Ident.Map.bindings mod_uses |> File.Map.of_list
+    in
+    match process_pending_errors ~on_error () with
+    | Error () ->
+      Partial
+        ( lsp_errors_to_diag doc_id (get_errors ()),
+          { Server_state.surface; prg; used_modules; jump_table } )
+    | Ok () -> k { Server_state.surface; prg; used_modules; jump_table })
+
 let process
     ~(resolve_file_content : string -> string Global.input_src)
     {
@@ -61,7 +220,7 @@ let process
       project;
       project_file;
       _;
-    } : Server_state.processing_result option * diagnostics =
+    } : Server_state.processing_result =
   let file = (doc_id :> File.t) in
   let input_src =
     match buffer_state with
@@ -92,172 +251,55 @@ let process
       ~input_src ()
   in
   let l = ref [] in
+  let get_errors () = !l in
   let on_error e =
     match e with
     | { Message.kind = Generic; pos = None; _ } -> ()
     | _ -> l := e :: !l
   in
   let () = Catala_utils.Message.register_lsp_error_notifier on_error in
-  let errors, result =
-    try
-      (* Resets the lexing context to a fresh one *)
-      Surface.Lexer_common.context := Law;
-      let prg =
-        Surface.Parser_driver.parse_top_level_file ?resolve_included_file
-          input_src
-      in
-      let (prg as surface) = prg in
-      match surface.Surface.Ast.program_module with
-      | Some { module_external = true; _ } ->
-        (* If the module is external, we skip it as the translation from
-           desugared would trigger an error *)
-        Log.debug (fun m -> m "skipping external module interface");
-        [], None
-      | _ ->
-        let root_dir, clerk_config =
-          match project.project_kind with
-          | Clerk { clerk_root_dir; clerk_config } ->
-            clerk_root_dir, clerk_config
-          | No_clerk -> project.project_dir, Clerk_config.default_config
-        in
-        let includes =
-          List.map Global.raw_file clerk_config.global.include_dirs
-        in
-        let mod_uses, modules =
-          let check stdlib k =
-            if File.exists stdlib then
-              Driver.load_modules options
-                ~stdlib:(Some (Global.raw_file stdlib))
-                includes prg
-            else k ()
-          in
-          let build_stdlib_path =
-            File.(root_dir / clerk_config.global.build_dir / "libcatala")
-          in
-          check build_stdlib_path
-          @@ fun () ->
-          Log.debug (fun m -> m "Stdlib not found - calling `clerk start`");
-          let _ = File.process_out "clerk" ["start"] in
-          check build_stdlib_path
-          @@ fun () ->
-          try
-            Driver.load_modules options
-              ~stdlib:(Some (Global.raw_file build_stdlib_path))
-              includes prg
-          with e ->
-            on_error
-              {
-                Message.kind = Generic;
-                message =
-                  (fun fmt ->
-                    Format.fprintf fmt
-                      "Did not find the Catala stdlib path, please build your \
-                       project");
-                pos = Some (Pos.from_info (doc_id :> string) 1 1 1 1);
-                suggestion = None;
-              };
-            raise e
-        in
-        let ctx =
-          Desugared.Name_resolution.form_context (prg, mod_uses) modules
-        in
-        let modules_content : Surface.Ast.module_content Uid.Module.Map.t =
-          Uid.Module.Map.map (fun elt -> fst elt) modules
-        in
-        let ctx, modules_contents = ctx, modules_content in
-        let prg =
-          Desugared.From_surface.translate_program ctx modules_contents prg
-        in
-        Message.report_delayed_errors_if_any ();
-        let prg = Desugared.Disambiguate.program prg in
-        Message.report_delayed_errors_if_any ();
-        let () = Desugared.Linting.lint_program prg in
-        let exceptions_graphs =
-          Scopelang.From_desugared.build_exceptions_graph prg
-        in
-        let prg =
-          Scopelang.From_desugared.translate_program prg exceptions_graphs
-          |> Scopelang.Ast.type_program
-        in
-        let () =
-          let _type_ordering =
-            Scopelang.Dependency.check_type_cycles
-              prg.program_ctx.ctx_abstract_types prg.program_ctx.ctx_structs
-              prg.program_ctx.ctx_enums
-          in
-          let prg = Dcalc.From_scopelang.translate_program prg in
-          ignore @@ Typing.program ~internal_check:true prg
-        in
-        let jump_table =
-          lazy (Jump_table.populate input_src ctx modules_contents surface prg)
-        in
-        let used_modules : ModuleName.t File.Map.t =
-          Ident.Map.bindings mod_uses |> File.Map.of_list
-        in
-        let result = { Server_state.prg; used_modules; jump_table } in
-        Message.report_delayed_errors_if_any ();
-        Log.info (fun m -> m "successful validation of %a" Doc_id.format doc_id);
-        !l, Some result
-    with e ->
-      let errors =
-        let e = match e with Fun.Finally_raised e -> e | e -> e in
-        match e with
-        | Catala_utils.Message.CompilerError er -> [er]
-        | Catala_utils.Message.CompilerErrors er_and_bt_l ->
-          List.map fst er_and_bt_l
-        | Failed_to_load_interface mod_use ->
-          let lsp_err = module_usage_error mod_use in
-          on_error lsp_err;
-          []
-        | e ->
-          on_error
-            {
-              Message.kind = Generic;
-              message =
-                (fun fmt ->
-                  Format.fprintf fmt
-                    "generic exception while processing document: %s"
-                    (Printexc.to_string e));
-              pos = None;
-              suggestion = None;
-            };
-          [
-            Format.ksprintf Message.Content.of_string "generic exception: %s"
-              (Printexc.to_string e);
-          ]
-      in
-      let err_len = List.length errors in
-      Log.debug (fun m ->
-          m "%d error(s) while processing document and %d diagnostics to send"
-            err_len (List.length !l));
-      List.iteri
-        (fun i er ->
-          let pp_err ppf = Message.Content.emit ~ppf er Error in
-          if err_len > 1 then
-            Log.debug (fun m -> m "error (%d/%d): %t" (succ i) err_len pp_err)
-          else Log.debug (fun m -> m "error: %t" pp_err))
-        errors;
-      List.rev !l, None
+  (* From surface to scopelang *)
+  surface_to_scopelang ~on_error ~get_errors ?resolve_included_file doc_id
+    options project
+  @@ fun ({ prg; _ } as valid_result) ->
+  let handle = function
+    | Ok () -> Server_state.Valid valid_result
+    | Error _errs ->
+      Server_state.Partial
+        (lsp_errors_to_diag doc_id (get_errors ()), valid_result)
   in
-  let diagnostics =
-    List.fold_left
-      (fun doc_map (err : Catala_utils.Message.lsp_error) ->
-        let uri, range =
-          match err.pos, err.kind with
-          | None, _ -> doc_id, dummy_range
-          | Some pos, Lexing ->
-            Doc_id.of_catala_pos pos, unclosed_range_of_pos pos
-          | Some pos, _ -> Doc_id.of_catala_pos pos, range_of_pos pos
-        in
-        let diag =
-          { range; lsp_error = Some err; diag = to_diagnostic range err }
-        in
-        Doc_id.Map.update uri
-          (function
-            | None -> Some (Range.Map.singleton range diag)
-            | Some x -> Some (Range.Map.add range diag x))
-          doc_map)
-      (Doc_id.Map.singleton doc_id Range.Map.empty)
-      errors
+  (* Linting *)
+  handle
+  @@ protect ~on_error
+  @@ fun () ->
+  let _type_ordering =
+    Scopelang.Dependency.check_type_cycles prg.program_ctx.ctx_abstract_types
+      prg.program_ctx.ctx_structs prg.program_ctx.ctx_enums
   in
-  result, diagnostics
+  let prg = Dcalc.From_scopelang.translate_program prg in
+  ignore @@ Typing.program ~internal_check:true prg;
+  Message.report_delayed_errors_if_any ()
+
+let process ~resolve_file_content document =
+  let r = process ~resolve_file_content document in
+  let nb_diags diags =
+    Doc_id.Map.fold
+      (fun _d rm i -> Server_types.Range.Map.cardinal rm + i)
+      diags 0
+  in
+  (match r with
+  | Skipped ->
+    Log.info (fun m ->
+        m "Skipped validation of %a" Doc_id.format document.document_id)
+  | Faulty diags ->
+    Log.info (fun m ->
+        m "Faulty validation of %a (%d errors)" Doc_id.format
+          document.document_id (nb_diags diags))
+  | Partial (diags, _) ->
+    Log.info (fun m ->
+        m "Partial validation of %a (%d non-fatal errors)" Doc_id.format
+          document.document_id (nb_diags diags))
+  | Valid _ ->
+    Log.info (fun m ->
+        m "Successful validation of %a" Doc_id.format document.document_id));
+  r

--- a/server/src/jump_table.ml
+++ b/server/src/jump_table.ml
@@ -645,6 +645,8 @@ let populate_modules
       { Surface.Ast.mod_use_name = name, pname; mod_use_alias = alias, palias }
       =
     try
+      let name = String.to_ascii name in
+      let alias = String.to_ascii alias in
       let mname = C.find name convert_map in
       let mname_pos = Mark.get (ModuleName.get_info mname) in
       let interface = ModuleName.Map.find mname modules_contents in
@@ -687,7 +689,8 @@ let populate_modules
     | None -> acc
     | Some { module_name; module_external = _ } -> (
       try
-        let mname = C.find (Mark.remove module_name) convert_map in
+        let name = String.to_ascii (Mark.remove module_name) in
+        let mname = C.find name convert_map in
         let mcontent = ModuleName.Map.find mname modules_contents in
         let interface =
           Surface.Parser_driver.load_interface

--- a/server/src/projects.mli
+++ b/server/src/projects.mli
@@ -24,7 +24,7 @@ module Scan_item : sig
 end
 
 module ScanItemFiles : Set.S with type elt = Clerk_scan.item
-module ModuleMap : Map.S with type key = string
+module ModuleMap : Catala_utils.Map.S with type key = string
 
 module Project_graph : sig
   type t

--- a/server/src/server.ml
+++ b/server/src/server.ml
@@ -94,8 +94,7 @@ let retrieve_existing_document_now doc_id server_state =
   protect_project_not_found_opt
   @@ fun () ->
   St.use_now server_state
-  @@ fun ({ open_documents; diagnostics; _ } as server_state) ->
-  Log.debug (fun m -> m "%a" Projects.format_projects server_state.projects);
+  @@ fun { open_documents; diagnostics; _ } ->
   match Doc_id.Map.find_opt doc_id open_documents with
   | None -> Lwt.return_none
   | Some doc -> Lwt.return_some (doc, diagnostics)
@@ -195,23 +194,37 @@ let unlocked_process_document document open_documents :
     | Some { St.buffer_state = Modified { contents }; _ } ->
       Global.Contents (contents, (doc_id :> string))
   in
-  let processing_result, diags =
+  let validation_result =
     Document_processing.process ~resolve_file_content document
+  in
+  let document = { document with last_result = Some validation_result } in
+  let is_valid, document, diags =
+    match validation_result with
+    | Skipped -> false, document, Doc_id.Map.empty
+    | Faulty diags -> false, document, diags
+    | Partial (diags, result) -> begin
+      if document.last_valid_result = None then
+        (* If the document was never valid, a partial result is better than
+           nothing... *)
+        false, { document with last_valid_result = Some result }, diags
+      else false, document, diags
+    end
+    | Valid result ->
+      ( true,
+        { document with last_valid_result = Some result },
+        (* We need to put an empty singleton in diags, otherwise the underlying
+           mechanism doesn't update the previous error... *)
+        Doc_id.Map.singleton document.document_id Range.Map.empty )
   in
   (* (\* Uncomment to display all symbols as warnings *\) *)
   (* let diags = *)
   (*   let extra_diags = *)
-  (*     Doc_queries.all_symbols_as_warning document.document_id processing_result *)
+  (*     Doc_queries.all_symbols_as_warning document.document_id validation_result *)
   (*   in *)
   (*   Doc_id.Map.union *)
   (*     (fun _ l r -> Some (Range.Map.union (fun _ _ r -> Some r) l r)) *)
   (*     diags extra_diags *)
   (* in *)
-  let is_valid, document =
-    match processing_result with
-    | None -> false, document
-    | valid_result -> true, { document with last_valid_result = valid_result }
-  in
   is_valid, document, diags
 
 let make_error_handler () =
@@ -563,7 +576,7 @@ class catala_lsp_server =
                       St.make_document St.Saved doc_id project project_file
                     | Some document -> document
                   in
-                  let _processed_file, document, document_diagnostics =
+                  let _is_valid, document, document_diagnostics =
                     unlocked_process_document document open_documents
                   in
                   let new_diagnostics =
@@ -662,7 +675,7 @@ class catala_lsp_server =
                   |> function
                   | Some { last_valid_result = Some { prg; _ }; _ } ->
                     Lwt.return_some prg
-                  | _ ->
+                  | _ -> (
                     let*? project_file =
                       Lwt.return
                         (Doc_id.Map.find_opt doc_id project.project_files)
@@ -673,15 +686,12 @@ class catala_lsp_server =
                     let document =
                       St.make_document St.Saved doc_id project project_file
                     in
-                    let r_opt =
-                      try
-                        fst
-                          (Document_processing.process ~resolve_file_content
-                             document)
-                      with _exn -> None
+                    let validation_result =
+                      Document_processing.process ~resolve_file_content document
                     in
-                    Lwt.return
-                      (Option.map (fun { Server_state.prg; _ } -> prg) r_opt)
+                    match validation_result with
+                    | Skipped | Faulty _ | Partial _ -> Lwt.return_none
+                    | Valid r -> Lwt.return_some r.prg)
                 in
                 list_entrypoints ~get_prog project params)
               all_projects

--- a/server/src/server.ml
+++ b/server/src/server.ml
@@ -399,7 +399,7 @@ class catala_lsp_server =
       InitializeParams.create ~capabilities:(ClientCapabilities.create ()) ()
 
     (* Extra-configurations *)
-    method! config_code_action_provider = `Bool true
+    method! config_code_action_provider = `Bool false
     method! config_completion = Some (CompletionOptions.create ())
     method! config_definition = Some (`Bool true)
     method! config_hover = Some (`Bool true)
@@ -729,55 +729,6 @@ class catala_lsp_server =
 
     method on_notif_doc_did_close ~notify_back d =
       self#on_doc_did_close ~notify_back (Doc_id.of_lsp_uri d.uri)
-
-    method! on_req_code_action ~notify_back:_ ~id:_
-        {
-          textDocument;
-          range;
-          context = _;
-          partialResultToken = _;
-          workDoneToken = _;
-        } : CodeActionResult.t Lwt.t =
-      let doc_id = Doc_id.of_lsp_uri textDocument.uri in
-      if should_ignore doc_id then Lwt.return_none
-      else
-        let* r = retrieve_existing_document_when_ready doc_id server_state in
-        match r with
-        | None -> Lwt.return_none
-        | Some ({ St.document_id; _ }, diagnostics) ->
-          let suggestions_opt =
-            DQ.lookup_suggestions document_id diagnostics range
-          in
-          let actions_opt : CodeAction.t list option =
-            Option.map
-              (fun (range, suggestions) ->
-                let changes : (DocumentUri.t * TextEdit.t list) list option =
-                  Option.some
-                  @@ List.map
-                       (fun suggestion ->
-                         ( textDocument.uri,
-                           [TextEdit.create ~range ~newText:suggestion] ))
-                       suggestions
-                in
-                [
-                  CodeAction.create ~title:"suggestions"
-                    ~kind:CodeActionKind.QuickFix ~isPreferred:true
-                    ~edit:
-                      {
-                        changes;
-                        documentChanges = None;
-                        changeAnnotations = None;
-                      }
-                    ();
-                ])
-              suggestions_opt
-          in
-          let result =
-            Option.map
-              (fun l -> List.map (fun action -> `CodeAction action) l)
-              actions_opt
-          in
-          Lwt.return result
 
     method! on_req_completion ~notify_back:_ ~id:_ ~uri ~pos ~ctx:_
         ~workDoneToken:_ ~partialResultToken:_ doc_state =

--- a/server/src/server.ml
+++ b/server/src/server.ml
@@ -198,6 +198,15 @@ let unlocked_process_document document open_documents :
   let processing_result, diags =
     Document_processing.process ~resolve_file_content document
   in
+  (* (\* Uncomment to display all symbols as warnings *\) *)
+  (* let diags = *)
+  (*   let extra_diags = *)
+  (*     Doc_queries.all_symbols_as_warning document.document_id processing_result *)
+  (*   in *)
+  (*   Doc_id.Map.union *)
+  (*     (fun _ l r -> Some (Range.Map.union (fun _ _ r -> Some r) l r)) *)
+  (*     diags extra_diags *)
+  (* in *)
   let is_valid, document =
     match processing_result with
     | None -> false, document

--- a/server/src/server.ml
+++ b/server/src/server.ml
@@ -411,6 +411,7 @@ class catala_lsp_server =
     method private config_declaration = Some (`Bool true)
     method private config_references = Some (`Bool true)
     method private config_type_definition = Some (`Bool true)
+    method private config_rename = Some (`Bool true)
 
     method! config_sync_opts =
       (* configure how sync happens *)
@@ -441,6 +442,7 @@ class catala_lsp_server =
           ?hoverProvider:self#config_hover
           ?inlayHintProvider:self#config_inlay_hints
           ?documentSymbolProvider:self#config_symbol
+          ?renameProvider:self#config_rename
           ~textDocumentSync:(`TextDocumentSyncOptions sync_opts)
           ~workspaceSymbolProvider:self#config_workspace_symbol
           ?typeDefinitionProvider:self#config_type_definition ()
@@ -705,6 +707,9 @@ class catala_lsp_server =
             ~pos:params.position ()
         | TextDocumentFormatting params ->
           self#on_req_document_formatting ~notify_back params
+        | TextDocumentRename params ->
+          self#on_req_document_rename ~notify_back params
+        | WorkspaceSymbol _params -> Lwt.return_none
         | UnknownRequest { meth = "catala.listEntrypoints"; params } ->
           self#list_entrypoints
             (Option.map Linol_jsonrpc.Jsonrpc.Structured.yojson_of_t params)
@@ -939,4 +944,40 @@ class catala_lsp_server =
           | Some r ->
             Log.info (fun m -> m "document formatting done");
             Lwt.return_some r)
+
+    method private on_req_document_rename ~notify_back:_
+        {
+          newName : string;
+          position : Types.Position.t;
+          textDocument : TextDocumentIdentifier.t;
+          _;
+        } : WorkspaceEdit.t Lwt.t =
+      let empty_response = WorkspaceEdit.create () in
+      let doc_id = Doc_id.of_lsp_uri textDocument.uri in
+      if should_ignore doc_id then Lwt.return empty_response
+      else
+        let* r =
+          protect_project_not_found_opt
+          @@ fun () ->
+          let*? doc, _ = retrieve_existing_document doc_id server_state in
+          let*? all_occurences =
+            Lwt.return (DQ.lookup_occurences doc position)
+          in
+          let changes : (Uri0.t * TextEdit.t list) list =
+            let open Server_types in
+            Doc_id.Map.map
+              (fun rs ->
+                Range.Set.elements rs
+                |> List.map (fun range ->
+                    TextEdit.create ~newText:newName ~range))
+              all_occurences
+            |> Doc_id.Map.bindings
+            |> List.map (fun (doc_id, ranges) ->
+                Doc_id.to_lsp_uri doc_id, ranges)
+          in
+          Lwt.return_some (WorkspaceEdit.create ~changes ())
+        in
+        match r with
+        | None -> Lwt.return empty_response
+        | Some r -> Lwt.return r
   end

--- a/server/src/server.ml
+++ b/server/src/server.ml
@@ -94,7 +94,8 @@ let retrieve_existing_document_now doc_id server_state =
   protect_project_not_found_opt
   @@ fun () ->
   St.use_now server_state
-  @@ fun { open_documents; diagnostics; _ } ->
+  @@ fun ({ open_documents; diagnostics; _ } as server_state) ->
+  Log.debug (fun m -> m "%a" Projects.format_projects server_state.projects);
   match Doc_id.Map.find_opt doc_id open_documents with
   | None -> Lwt.return_none
   | Some doc -> Lwt.return_some (doc, diagnostics)
@@ -779,29 +780,19 @@ class catala_lsp_server =
           Lwt.return result
 
     method! on_req_completion ~notify_back:_ ~id:_ ~uri ~pos ~ctx:_
-        ~workDoneToken:_ ~partialResultToken:_ _doc_state =
+        ~workDoneToken:_ ~partialResultToken:_ doc_state =
       let doc_id = Doc_id.of_lsp_uri uri in
       if should_ignore doc_id then Lwt.return_none
       else
-        let*? { St.document_id; _ }, diagnostics =
+        let*? document, diagnostics =
           retrieve_existing_document_now doc_id server_state
         in
-        let suggestions_opt =
-          DQ.lookup_suggestions_by_pos document_id diagnostics pos
-        in
-        match suggestions_opt with
-        | None -> Lwt.return_none
-        | Some (range, suggestions) ->
+        let*? completions =
           Lwt.return
-          @@ Some
-               (`List
-                  (List.map
-                     (fun sugg ->
-                       let textEdit =
-                         `TextEdit (TextEdit.create ~range ~newText:sugg)
-                       in
-                       CompletionItem.create ~label:sugg ~textEdit ())
-                     suggestions))
+            (DQ.lookup_completions document ~doc_content:doc_state.content pos
+               diagnostics)
+        in
+        Lwt.return_some (`List completions)
 
     method! on_req_definition ~notify_back:_ ~id:_ ~uri ~pos ~workDoneToken:_
         ~partialResultToken:_ _doc_state =
@@ -896,6 +887,7 @@ class catala_lsp_server =
         | `SymbolInformation of SymbolInformation.t list ]
         option
         t =
+      Log.info (fun m -> m "DOCUMENT SYMBOL REQUEST");
       let doc_id = Doc_id.of_lsp_uri uri in
       if should_ignore doc_id then Lwt.return_none
       else

--- a/server/src/server_state.ml
+++ b/server/src/server_state.ml
@@ -19,11 +19,18 @@ open Lwt.Syntax
 open Shared_ast
 open Catala_utils
 
-type processing_result = {
+type valid_result = {
+  surface : Surface.Ast.program;
   prg : typed Scopelang.Ast.program;
   used_modules : ModuleName.t File.Map.t;
   jump_table : Jump_table.t Lazy.t;
 }
+
+type processing_result =
+  | Skipped
+  | Faulty of diagnostics
+  | Partial of diagnostics * valid_result
+  | Valid of valid_result
 
 type buffer_state = Saved | Modified of { contents : string }
 
@@ -33,7 +40,8 @@ type document_state = {
   buffer_state : buffer_state;
   project : Projects.project;
   project_file : Projects.project_file;
-  last_valid_result : processing_result option;
+  last_valid_result : valid_result option;
+  last_result : processing_result option;
 }
 
 let make_document buffer_state (document_id : Doc_id.t) project project_file =
@@ -45,6 +53,7 @@ let make_document buffer_state (document_id : Doc_id.t) project project_file =
     project;
     project_file;
     last_valid_result = None;
+    last_result = None;
   }
 
 type server_state = {

--- a/server/src/server_state.mli
+++ b/server/src/server_state.mli
@@ -18,11 +18,18 @@ open Shared_ast
 open Catala_utils
 open Server_types
 
-type processing_result = {
+type valid_result = {
+  surface : Surface.Ast.program;
   prg : typed Scopelang.Ast.program;
   used_modules : ModuleName.t File.Map.t;
   jump_table : Jump_table.t Lazy.t;
 }
+
+type processing_result =
+  | Skipped
+  | Faulty of diagnostics
+  | Partial of diagnostics * valid_result
+  | Valid of valid_result
 
 type buffer_state = Saved | Modified of { contents : string }
 
@@ -32,7 +39,8 @@ type document_state = {
   buffer_state : buffer_state;
   project : Projects.project;
   project_file : Projects.project_file;
-  last_valid_result : processing_result option;
+  last_valid_result : valid_result option;
+  last_result : processing_result option;
 }
 
 val make_document :

--- a/server/src/type_printing.ml
+++ b/server/src/type_printing.ml
@@ -298,14 +298,28 @@ let svar_io_s locale (var_io : Desugared.Ast.io) =
   | None, Some s | Some s, None -> Some s
   | None, None -> None (* internal *)
 
+let svar_internal_s = function
+  | Global.En -> "output"
+  | Fr -> "résultat"
+  | Pl -> assert false
+
+let svar_state_s = function
+  | Global.En -> "state"
+  | Fr -> "état"
+  | Pl -> assert false
+
 let pp_scope_var
+    ?(skip_internals = true)
     locale
     fmt
     ((scope_var : ScopeVar.t), (scope_ty : Scopelang.Ast.scope_var_ty)) =
   let open Format in
   let var_name = ScopeVar.to_string scope_var in
   match svar_io_s locale scope_ty.svar_io with
-  | None -> (* internal *) ()
+  | None when skip_internals -> (* internal *) ()
+  | None ->
+    fprintf fmt "@[<hov 2>%s %s %s %a@]" (svar_internal_s locale) var_name
+      (content locale) (pp_typ_no_box locale) scope_ty.svar_out_ty
   | Some io_s ->
     fprintf fmt "@[<hov 2>%s %s %s %a@]" io_s var_name (content locale)
       (pp_typ_no_box locale) scope_ty.svar_out_ty
@@ -314,13 +328,14 @@ let is_svar_internal (scope_ty : Scopelang.Ast.scope_var_ty) =
   (not (Mark.remove scope_ty.svar_io.io_output))
   && Mark.remove scope_ty.svar_io.io_input = Catala_runtime.NoInput
 
-let pp_scope locale fmt (scope_name, scope_vars) =
+let pp_scope ?(skip_internals = true) locale fmt (scope_name, scope_vars) =
   let open Format in
   let short_scope_name = ScopeName.get_info scope_name |> fst in
   fprintf fmt "@[<v 2>%s %s:@ %a@]" (scope_s locale) short_scope_name
-    (pp_print_list ~pp_sep:pp_print_space (pp_scope_var locale))
+    (pp_print_list ~pp_sep:pp_print_space (pp_scope_var ~skip_internals locale))
     (ScopeVar.Map.bindings scope_vars
-    |> List.filter (fun (_, v) -> not (is_svar_internal v)))
+    |> List.filter (fun (_, v) ->
+        (not skip_internals) || not (is_svar_internal v)))
 
 let sig_type
     ~markdown

--- a/server/src/type_printing.ml
+++ b/server/src/type_printing.ml
@@ -95,6 +95,11 @@ let option_s = function
   | Fr -> "optionnel de"
   | Pl -> assert false
 
+let using_s = function
+  | Global.En -> "Using"
+  | Fr -> "Usage de"
+  | Pl -> assert false
+
 let pp_lit locale fmt l =
   fprintf fmt "%s"
   @@ (if locale = Global.En then fst else snd)

--- a/server/src/type_printing.ml
+++ b/server/src/type_printing.ml
@@ -19,7 +19,10 @@ open Catala_utils
 open Shared_ast
 open Format
 
-let for_all = function
+let locale_s locale =
+  match locale with Global.En -> "en" | Fr -> "fr" | Pl -> assert false
+
+let _for_all = function
   | Global.En -> "anything of type"
   | Fr -> "n'importe quel de type"
   | Pl -> assert false
@@ -38,8 +41,8 @@ let enum = function Global.En -> "enum" | Fr -> "énum" | Pl -> assert false
 let struct_s = function Global.Pl -> assert false | _ -> "structure"
 
 let struct_header = function
-  | Global.En -> "declaration " ^ struct_s En
-  | Fr -> "déclaration " ^ struct_s Fr
+  | Global.En -> struct_s En
+  | Fr -> struct_s Fr
   | Pl -> assert false
 
 let struct_data = function
@@ -52,14 +55,19 @@ let content = function
   | Fr -> "contenu"
   | Pl -> assert false
 
+let depends_on = function
+  | Global.En -> "depends on"
+  | Fr -> "dépend de"
+  | Pl -> assert false
+
 let enum_s = function
   | Global.En -> "enumeration"
   | Fr -> "énumération"
   | Pl -> assert false
 
 let enum_header = function
-  | Global.En -> "declaration " ^ enum_s En
-  | Fr -> "déclaration " ^ enum_s Fr
+  | Global.En -> enum_s En
+  | Fr -> enum_s Fr
   | Pl -> assert false
 
 let scope_s = function
@@ -82,6 +90,11 @@ let alias_s = function
   | Fr -> "en tant que"
   | Pl -> assert false
 
+let option_s = function
+  | Global.En -> "optional of"
+  | Fr -> "optionnel de"
+  | Pl -> assert false
+
 let pp_lit locale fmt l =
   fprintf fmt "%s"
   @@ (if locale = Global.En then fst else snd)
@@ -96,29 +109,32 @@ let pp_lit locale fmt l =
        | TPos -> "position", "position")
 
 let pp_typ locale fmt (ty : typ) =
+  let untuplify = function [(TTuple tys, _)] -> tys | x -> x in
   let rec pp_typ fmt ty =
     match Mark.remove ty with
     | TLit l -> pp_lit locale fmt l
-    | TVar v -> pp_print_string fmt (Bindlib.name_of v)
+    | TVar v -> fprintf fmt "<%s>" (Bindlib.name_of v)
     | TForAll b ->
       let _, typ = Bindlib.unmbind b in
-      fprintf fmt "@[<hov 2>%s %a@]" (for_all locale) pp_typ typ
-    | TArrow ([t1], t2) -> fprintf fmt "@[<hov>%a@ →@ %a@]" pp_typ t1 pp_typ t2
+      (* We do not display the for-all information: it's too verbose *)
+      pp_typ fmt typ
     | TArrow (t1, t2) ->
-      fprintf fmt "@[<hov>(%a)@ →@ %a@]"
-        (pp_print_list ~pp_sep:(fun fmt () -> fprintf fmt ",@ ") pp_typ)
-        t1 pp_typ t2
+      fprintf fmt "@[<hov>%a@ →@ %a@]"
+        (pp_print_list ~pp_sep:(fun fmt () -> fprintf fmt "@ →@ ") pp_typ)
+        (untuplify t1) pp_typ t2
     | TTuple tys ->
       fprintf fmt "@[<hov 2>(%a)@]"
         (pp_print_list ~pp_sep:(fun fmt () -> Format.fprintf fmt ",@ ") pp_typ)
         tys
     | TStruct s ->
+      let s = Utils.rename_alias_in_path locale StructName.map_info s in
       fprintf fmt "@[<hov 2>%a <struct>@]" StructName.format_shortpath s
     | TEnum e ->
+      let e = Utils.rename_alias_in_path locale EnumName.map_info e in
       fprintf fmt "@[<hov 2>%a <%s>@]" EnumName.format_shortpath e (enum locale)
-    | TOption o -> fprintf fmt "@[<hov 2>%a@ <option>@]" pp_typ o
+    | TOption o -> fprintf fmt "@[<hov 2>%s@ %a@]" (option_s locale) pp_typ o
     | TArray a -> fprintf fmt "@[<hov 2>%s@ %a@]" (list_of locale) pp_typ a
-    | TDefault d -> fprintf fmt "@[<hov 2>%a@ <%s>@]" pp_typ d (default locale)
+    | TDefault d -> pp_typ fmt d
     | TAbstract t ->
       fprintf fmt "@[<hov 2>%a <abstract>@]" AbstractType.format_shortpath t
     | TClosureEnv -> fprintf fmt "<closure_env>"
@@ -127,27 +143,32 @@ let pp_typ locale fmt (ty : typ) =
   pp_typ fmt ty
 
 let pp_typ_no_box locale fmt (ty : typ) =
+  let untuplify = function [(TTuple tys, _)] -> tys | x -> x in
   let rec pp_typ fmt ty =
     match Mark.remove ty with
     | TLit l -> pp_lit locale fmt l
-    | TVar v -> pp_print_string fmt (Bindlib.name_of v)
+    | TVar v -> fprintf fmt "<%s>" (Bindlib.name_of v)
     | TForAll b ->
       let _, typ = Bindlib.unmbind b in
-      fprintf fmt "%s %a" (for_all locale) pp_typ typ
-    | TArrow ([t1], t2) -> fprintf fmt "%a@ →@ %a" pp_typ t1 pp_typ t2
+      (* We do not display the for-all information: it's too verbose *)
+      pp_typ fmt typ
     | TArrow (t1, t2) ->
-      fprintf fmt "(%a)@ →@ %a"
-        (pp_print_list ~pp_sep:(fun fmt () -> fprintf fmt ",@ ") pp_typ)
-        t1 pp_typ t2
+      fprintf fmt "%a@ → %a"
+        (pp_print_list ~pp_sep:(fun fmt () -> fprintf fmt "@ →@ ") pp_typ)
+        (untuplify t1) pp_typ t2
     | TTuple tys ->
       fprintf fmt "(%a)"
         (pp_print_list ~pp_sep:(fun fmt () -> Format.fprintf fmt ",@ ") pp_typ)
         tys
-    | TStruct s -> fprintf fmt "%a <struct>" StructName.format_shortpath s
-    | TEnum e -> fprintf fmt "%a <%s>" EnumName.format_shortpath e (enum locale)
-    | TOption o -> fprintf fmt "%a@ <option>" pp_typ o
+    | TStruct s ->
+      let s = Utils.rename_alias_in_path locale StructName.map_info s in
+      fprintf fmt "%a <struct>" StructName.format_shortpath s
+    | TEnum e ->
+      let e = Utils.rename_alias_in_path locale EnumName.map_info e in
+      fprintf fmt "%a <%s>" EnumName.format_shortpath e (enum locale)
+    | TOption o -> fprintf fmt "%s@ %a" (option_s locale) pp_typ o
     | TArray a -> fprintf fmt "%s@ %a" (list_of locale) pp_typ a
-    | TDefault d -> fprintf fmt "%a@ <%s>" pp_typ d (default locale)
+    | TDefault d -> fprintf fmt "%a" pp_typ d
     | TAbstract t -> fprintf fmt "%a <abstract>" AbstractType.format_shortpath t
     | TClosureEnv -> fprintf fmt "<closure_env>"
     | TError -> fprintf fmt "<error>"
@@ -160,7 +181,7 @@ let expr_type ~markdown locale typ =
   in
   let typ_s =
     if markdown then
-      asprintf "```catala_type_%s@\n%a@\n```" locale_s (pp_typ locale) typ
+      asprintf "```catala_code_%s@\n%a@\n```" locale_s (pp_typ locale) typ
     else asprintf "%a" (pp_typ locale) typ
   in
   typ_s
@@ -306,20 +327,25 @@ let sig_type
     locale
     scope_name
     (scope_vars : Scopelang.Ast.scope_var_ty ScopeVar.Map.t) =
-  let locale_s =
-    match locale with Global.En -> "en" | Fr -> "fr" | Pl -> assert false
-  in
   let typ_s =
     if markdown then
-      asprintf "```catala_code_%s@\n%a@\n```" locale_s (pp_scope locale)
-        (scope_name, scope_vars)
+      asprintf "```catala_code_%s@\n%a@\n```" (locale_s locale)
+        (pp_scope locale) (scope_name, scope_vars)
     else asprintf "%a" (pp_scope locale) (scope_name, scope_vars)
   in
   typ_s
 
-let pp_module locale fmt (mcontent : Surface.Ast.module_content) =
+let pp_topdef locale fmt (name, topdef_typ) =
+  fprintf fmt "%s %s : %a" (topdef_s locale) name (pp_typ locale) topdef_typ
+
+let pp_module
+    locale
+    (prg : Shared_ast.typed Scopelang.Ast.program)
+    fmt
+    (mcontent : Surface.Ast.module_content) =
   let open Format in
   let open Surface.Ast in
+  let ctx = prg.program_ctx in
   (* From Surface.Ast :
 
      > Invariant: an interface shall only contain [*Decl] elements, or [Topdef]
@@ -332,8 +358,17 @@ let pp_module locale fmt (mcontent : Surface.Ast.module_content) =
       fprintf fmt "%s %s" (struct_s locale) (Mark.remove sdecl.struct_decl_name)
     | EnumDecl edecl ->
       fprintf fmt "%s %s" (enum_s locale) (Mark.remove edecl.enum_decl_name)
-    | Topdef top_def ->
-      fprintf fmt "%s %s" (topdef_s locale) (Mark.remove top_def.topdef_name)
+    | Topdef top_def -> (
+      match
+        TopdefName.Map.bindings ctx.ctx_topdefs
+        |> List.find_opt (fun (topdef_name, _) ->
+            String.equal
+              (TopdefName.base topdef_name)
+              (Mark.remove top_def.topdef_name))
+      with
+      | None -> () (* ?? *)
+      | Some (_, (topdef_typ, _)) ->
+        pp_topdef locale fmt (Mark.remove top_def.topdef_name, topdef_typ))
     | AbstractTypeDecl t ->
       fprintf fmt "%s %s" (external_type_s locale) (Mark.remove t)
     | ScopeUse _ -> ()
@@ -362,39 +397,40 @@ let pp_module locale fmt (mcontent : Surface.Ast.module_content) =
 
 let module_type
     ~markdown
+    prg
     locale
     ?alias
     (module_content : Surface.Ast.module_content) =
-  let locale_s =
-    match locale with Global.En -> "en" | Fr -> "fr" | Pl -> assert false
-  in
   let buf = Buffer.create 128 in
   let ppf = Format.formatter_of_buffer buf in
+  let module_name =
+    let name = fst module_content.module_modname.module_name in
+    try Utils.lookup_alias_name locale name
+    with String.Map.Not_found _ | Not_found -> name
+  in
   let () =
-    fprintf ppf "**Module %s%a**@\n"
-      (fst module_content.module_modname.module_name)
+    fprintf ppf "**Module %s%a**@\n" module_name
       (Utils.pp_opt (fun fmt alias ->
            Format.fprintf fmt " (%s %s)" (alias_s locale) alias))
       alias;
-    if markdown then fprintf ppf "```catala_code_%s@\n" locale_s;
-    fprintf ppf "%a@\n" (pp_module locale) module_content;
+    if markdown then fprintf ppf "```catala_code_%s@\n" (locale_s locale);
+    fprintf ppf "%a@\n" (pp_module locale prg) module_content;
     if markdown then fprintf ppf "```"
   in
   Buffer.contents buf
 
-let typ_to_content ~markdown ?prg locale (kind : Jump_table.type_lookup) =
-  match prg, kind with
-  | Some prg, (Type typ | Expr typ) -> data_type ~markdown prg locale typ
-  | None, (Type typ | Expr typ) -> expr_type ~markdown locale typ
-  | _, Scope (sn, scope_var_map) -> sig_type ~markdown locale sn scope_var_map
-  | _, Module (itf, alias) -> module_type ~markdown locale ?alias itf
+let typ_to_content ~markdown prg locale (kind : Jump_table.type_lookup) =
+  match kind with
+  | Type typ | Expr typ -> data_type ~markdown prg locale typ
+  | Scope (sn, scope_var_map) -> sig_type ~markdown locale sn scope_var_map
+  | Module (itf, alias) -> module_type ~markdown prg locale ?alias itf
 
-let typ_to_markdown ?prg locale (kind : Jump_table.type_lookup) :
-    MarkupContent.t =
-  let value = typ_to_content ~markdown:true ?prg locale kind in
+let typ_to_markdown prg locale (kind : Jump_table.type_lookup) : MarkupContent.t
+    =
+  let value = typ_to_content ~markdown:true prg locale kind in
   MarkupContent.create ~kind:Markdown ~value
 
-let typ_to_raw_string ?prg locale (kind : Jump_table.type_lookup) :
+let typ_to_raw_string prg locale (kind : Jump_table.type_lookup) :
     MarkedString.t =
-  let value = typ_to_content ~markdown:false ?prg locale kind in
+  let value = typ_to_content ~markdown:false prg locale kind in
   { MarkedString.value; language = None }

--- a/server/src/utils.ml
+++ b/server/src/utils.ml
@@ -21,6 +21,7 @@ open Server_types
 
 let ( let*? ) = Option.bind
 let ( let*?! ) (x, default) f = match x with None -> default | Some x -> f x
+let ( let*! ) x f = match x with None -> f () | Some x -> Some x
 let never_ending = fst (Lwt.wait ())
 
 let pp_opt pp fmt =
@@ -33,6 +34,7 @@ let pp_list pp fmt =
     (pp_print_list ~pp_sep:(fun fmt () -> fprintf fmt " ;@ ") pp)
 
 let pp_string_list fmt = pp_list Format.pp_print_string fmt
+let option_of_list = function [] -> None | l -> Some l
 
 let is_included (p : Pos.t) p' =
   (* true if p is included in p' *)
@@ -164,7 +166,8 @@ let lookup_clerk_toml (path : string) =
   let open Catala_utils in
   try
     begin match
-      File.find_in_parents ~cwd:from_dir (fun dir -> File.(exists (dir / "clerk.toml")))
+      File.find_in_parents ~cwd:from_dir (fun dir ->
+          File.(exists (dir / "clerk.toml")))
     with
     | None ->
       Log.debug (fun m -> m "no 'clerk.toml' config file found");

--- a/server/src/utils.ml
+++ b/server/src/utils.ml
@@ -254,3 +254,55 @@ let get_timestamp ?(no_brackets = false) () =
   in
   if no_brackets then Format.asprintf "%02d:%02d:%02d.%02Ld" hh mm ss cs
   else Format.asprintf "[%02d:%02d:%02d.%02Ld]" hh mm ss cs
+
+let lookup_alias_name =
+  (* TODO: officialize this list in catala/clerk directly *)
+  let en_names =
+    [
+      "Date";
+      "Duration";
+      "MonthYear";
+      "Period";
+      "Money";
+      "Integer";
+      "Decimal";
+      "List";
+    ]
+  in
+  let en_aliases = List.map (fun s -> s ^ "_en") en_names in
+  let fr_aliases = List.map (fun s -> s ^ "_fr") en_names in
+  let fr_names =
+    [
+      "Date";
+      "Durée";
+      "MoisAnnée";
+      "Période";
+      "Argent";
+      "Entier";
+      "Décimal";
+      "Liste";
+    ]
+  in
+  let en_alias_map = String.Map.of_list (List.combine en_aliases en_names) in
+  let fr_alias_map = String.Map.of_list (List.combine fr_aliases fr_names) in
+  let lookup_alias_name lang s =
+    match lang with
+    | Catala_utils.Global.Fr -> String.Map.find s fr_alias_map
+    | Catala_utils.Global.En | _ -> String.Map.find s en_alias_map
+  in
+  lookup_alias_name
+
+let rename_alias_in_path locale map_info x =
+  map_info
+    (fun (path, r) ->
+      ( List.map
+          (fun m ->
+            try
+              let alias =
+                lookup_alias_name locale (Shared_ast.ModuleName.to_string m)
+              in
+              Shared_ast.ModuleName.fresh (alias, Pos.void)
+            with _ -> m)
+          path,
+        r ))
+    x

--- a/server/src/utils.ml
+++ b/server/src/utils.ml
@@ -34,6 +34,14 @@ let pp_list pp fmt =
     (pp_print_list ~pp_sep:(fun fmt () -> fprintf fmt " ;@ ") pp)
 
 let pp_string_list fmt = pp_list Format.pp_print_string fmt
+
+let pp_range fmt { Linol_lwt.Range.start; end_ } =
+  let open Format in
+  let pp_pos fmt { Linol_lwt.Position.line; character } =
+    fprintf fmt "l:%d, c:%d" line character
+  in
+  fprintf fmt "start:(%a), end:(%a)" pp_pos start pp_pos end_
+
 let option_of_list = function [] -> None | l -> Some l
 
 let is_included (p : Pos.t) p' =


### PR DESCRIPTION
This PR adds an ad hoc completion in vscode. In particular, it auto-completes, given a prefix, to a reasonable suffix given the last valid computed program context. N.b., if the program was never valid, no completion context will be available until a "sufficiently" valid program is given. The completion is purely syntactic, not semantic.

<img width="1646" height="772" alt="image" src="https://github.com/user-attachments/assets/3f419b90-cb8a-4c5a-9cec-d6c2889fbb8b" />

Depends on https://github.com/CatalaLang/catala/pull/997

N.b. vscode does its own thing to render markdown in tool-tips, I need to explore ways to improve the rendering but it shouldn't be a blocking point. 
Also, users can resize the tooltip even though there are no visual cues.