### PR TITLE
Support context variables in test GUI

### DIFF
--- a/catala-atd/catala_types.atd
+++ b/catala-atd/catala_types.atd
@@ -27,10 +27,15 @@ type struct_declaration = {
   fields: (string * typ) list <json repr="object"> <ts repr="map">;
 }
 
+type scope_input = {
+  typ: typ;
+  is_context: bool;
+}
+
 type scope_def = {
   name: string;
   module_name: string;
-  inputs: (string * typ) list <json repr="object"> <ts repr="map">;
+  inputs: (string * scope_input) list <json repr="object"> <ts repr="map">;
   outputs: (string * typ) list <json repr="object"> <ts repr="map">;
   module_deps : string list;
 }

--- a/catala-atd/catala_types.atd
+++ b/catala-atd/catala_types.atd
@@ -74,19 +74,15 @@ type runtime_value_raw = [
   | Struct of (struct_declaration * (string * runtime_value) list <json repr="object"> <ts repr="map">)
   | Array of runtime_value list <ocaml repr="array">
   | Unset
-    (* Sentinel with two distinct meanings depending on the variable kind:
-
-       1. Regular input (is_context = false): "not yet provided".
-          Must be filled by the user before running a test. Printed as
-          'impossible' in Catala output. The test runner rejects any
-          remaining Unset on regular inputs.
-
-       2. Context variable (is_context = true): "no override — use the
-          scope-computed default". The variable is omitted from the
-          generated Catala test entirely. This is the reset/clear action.
-
-       TODO: these two roles should be separate variants, Unset and
-       UseComputedDefault, so the type system enforces the distinction. *)
+    (* Regular input (is_context = false): "not yet provided".
+       Must be filled by the user before running a test. Printed as
+       'impossible' in Catala output. The test runner rejects any
+       remaining Unset on regular inputs. *)
+  | NotOverridden
+    (* Context variable (is_context = true): "no override — use the
+       scope-computed default". The variable is omitted from the JSON
+       input sent to the runtime. This is the reset/clear action for
+       context vars. Must never appear on non-context inputs. *)
   | Empty (* for diffs *)
 ] <ocaml repr="classic">
 

--- a/catala-atd/catala_types.atd
+++ b/catala-atd/catala_types.atd
@@ -73,7 +73,20 @@ type runtime_value_raw = [
   | Enum of (enum_declaration * (string * runtime_value option))
   | Struct of (struct_declaration * (string * runtime_value) list <json repr="object"> <ts repr="map">)
   | Array of runtime_value list <ocaml repr="array">
-  | Unset (* GUI placeholder for 'impossible' value *)
+  | Unset
+    (* Sentinel with two distinct meanings depending on the variable kind:
+
+       1. Regular input (is_context = false): "not yet provided".
+          Must be filled by the user before running a test. Printed as
+          'impossible' in Catala output. The test runner rejects any
+          remaining Unset on regular inputs.
+
+       2. Context variable (is_context = true): "no override — use the
+          scope-computed default". The variable is omitted from the
+          generated Catala test entirely. This is the reset/clear action.
+
+       TODO: these two roles should be separate variants, Unset and
+       UseComputedDefault, so the type system enforces the distinction. *)
   | Empty (* for diffs *)
 ] <ocaml repr="classic">
 

--- a/catala-atd/catala_types.atd
+++ b/catala-atd/catala_types.atd
@@ -186,6 +186,7 @@ type confirm_action = [
   | DeleteArrayElement
   | DeleteAssertion
   | RunTestWithUnsetValues
+  | ResetContextVar
 ]
 
 type confirm_request = {

--- a/src/editors/CompositeEditor.tsx
+++ b/src/editors/CompositeEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement } from 'react';
+import { useState, type ReactElement, type ReactNode } from 'react';
 import { hasNestedArrays } from './ArrayEditor';
 import type { Typ } from '../generated/catala_types';
 
@@ -27,7 +27,7 @@ import type { Typ } from '../generated/catala_types';
 
 export type EditorItem = {
   key: string;
-  label: string;
+  label: ReactNode;
   type: Typ;
   editor: ReactElement;
 };
@@ -43,7 +43,7 @@ export function CompositeEditor(props: CompositeEditorProps): ReactElement {
   const complexItems = props.items.filter((item) => hasNestedArrays(item.type));
 
   // Helper function to get tab display name with count for arrays
-  function getTabDisplayName(item: EditorItem): string {
+  function getTabDisplayName(item: EditorItem): ReactNode {
     // Check if this is an array type
     if (item.type.kind === 'TArray') {
       // Try to extract array length from the editor props
@@ -62,7 +62,7 @@ export function CompositeEditor(props: CompositeEditorProps): ReactElement {
       // Look for testIO prop which might contain our array value
       const arrayValue = editorProps?.testIO?.value?.value?.value;
       if (arrayValue?.kind === 'Array' && arrayValue.value) {
-        return `${item.label} (${arrayValue.value.length})`;
+        return `${item.key} (${arrayValue.value.length})`;
       }
     }
 

--- a/src/editors/unsetValidation.ts
+++ b/src/editors/unsetValidation.ts
@@ -1,12 +1,12 @@
 /**
  * Utilities for detecting and navigating to Unset/Invalid values in RuntimeValue trees.
+ * Note: NotOverridden (context var using computed default) is intentionally
+ * not treated as Unset — it is valid and does not block test runs.
  */
 
-import type { RuntimeValue, ScopeDef, Test } from '../generated/catala_types';
+import type { RuntimeValue, Test } from '../generated/catala_types';
 
-/**
- * Recursively checks if a RuntimeValue contains any Unset values.
- */
+/** Recursively checks whether a RuntimeValue contains any Unset values. */
 function containsUnset(rv: RuntimeValue): boolean {
   switch (rv.value.kind) {
     case 'Unset':
@@ -49,26 +49,19 @@ export function scrollToFirstInvalidOrUnset(
   }, delay);
 }
 
-/**
- * Checks if a Test has any Unset values in inputs and/or outputs.
- * Context variables (is_context=true) are excluded from the inputs check
- * since an Unset context var means "use computed default", not "missing value".
- */
 export function hasUnsetInTest(
   test: Test,
   options: {
     checkInputs?: boolean;
     checkOutputs?: boolean;
-    testedScope?: ScopeDef;
   } = {}
 ): boolean {
-  const { checkInputs = true, checkOutputs = true, testedScope } = options;
+  const { checkInputs = true, checkOutputs = true } = options;
 
   const inputsHas = checkInputs
-    ? Array.from(test.test_inputs.entries()).some(([name, io]) => {
-        if (testedScope?.inputs.get(name)?.is_context) return false;
-        return io.value && containsUnset(io.value.value);
-      })
+    ? Array.from(test.test_inputs.values()).some(
+        (io) => io.value && containsUnset(io.value.value)
+      )
     : false;
 
   const outputsHas = checkOutputs

--- a/src/editors/unsetValidation.ts
+++ b/src/editors/unsetValidation.ts
@@ -2,7 +2,7 @@
  * Utilities for detecting and navigating to Unset/Invalid values in RuntimeValue trees.
  */
 
-import type { RuntimeValue, Test } from '../generated/catala_types';
+import type { RuntimeValue, ScopeDef, Test } from '../generated/catala_types';
 
 /**
  * Recursively checks if a RuntimeValue contains any Unset values.
@@ -51,17 +51,24 @@ export function scrollToFirstInvalidOrUnset(
 
 /**
  * Checks if a Test has any Unset values in inputs and/or outputs.
+ * Context variables (is_context=true) are excluded from the inputs check
+ * since an Unset context var means "use computed default", not "missing value".
  */
 export function hasUnsetInTest(
   test: Test,
-  options: { checkInputs?: boolean; checkOutputs?: boolean } = {}
+  options: {
+    checkInputs?: boolean;
+    checkOutputs?: boolean;
+    testedScope?: ScopeDef;
+  } = {}
 ): boolean {
-  const { checkInputs = true, checkOutputs = true } = options;
+  const { checkInputs = true, checkOutputs = true, testedScope } = options;
 
   const inputsHas = checkInputs
-    ? Array.from(test.test_inputs.values()).some(
-        (io) => io.value && containsUnset(io.value.value)
-      )
+    ? Array.from(test.test_inputs.entries()).some(([name, io]) => {
+        if (testedScope?.inputs.get(name)?.is_context) return false;
+        return io.value && containsUnset(io.value.value);
+      })
     : false;
 
   const outputsHas = checkOutputs

--- a/src/extension/testCaseEditorProvider.ts
+++ b/src/extension/testCaseEditorProvider.ts
@@ -401,8 +401,11 @@ export class TestCaseEditorProvider
           const messages = getLocalizedMessages(vscode.env.language);
 
           let prompt: string;
-          let buttons: Array<{ title: string; action: 'Delete' | 'RunAnyway' }>;
-          let successAction: 'Delete' | 'RunAnyway';
+          let buttons: Array<{
+            title: string;
+            action: 'Delete' | 'RunAnyway' | 'Reset';
+          }>;
+          let successAction: 'Delete' | 'RunAnyway' | 'Reset';
 
           switch (action.kind) {
             case 'DeleteArrayElement':
@@ -421,6 +424,13 @@ export class TestCaseEditorProvider
                 { title: messages.runAnywayButton, action: 'RunAnyway' },
               ];
               successAction = 'RunAnyway';
+              break;
+            case 'ResetContextVar':
+              prompt = messages.resetContextVarConfirmation;
+              buttons = [
+                { title: messages.resetContextVarButton, action: 'Reset' },
+              ];
+              successAction = 'Reset';
               break;
             default:
               assertUnreachable(action as never);

--- a/src/generated/catala_types.ts
+++ b/src/generated/catala_types.ts
@@ -85,6 +85,7 @@ export type RuntimeValueRaw =
 | { kind: 'Struct'; value: [StructDeclaration, Map<string, RuntimeValue>] }
 | { kind: 'Array'; value: RuntimeValue[] }
 | { kind: 'Unset' }
+| { kind: 'NotOverridden' }
 | { kind: 'Empty' }
 
 export type AttrDef =
@@ -489,6 +490,8 @@ export function writeRuntimeValueRaw(x: RuntimeValueRaw, context: any = x): any 
       return ['Array', _atd_write_array(writeRuntimeValue)(x.value, x)]
     case 'Unset':
       return 'Unset'
+    case 'NotOverridden':
+      return 'NotOverridden'
     case 'Empty':
       return 'Empty'
   }
@@ -499,6 +502,8 @@ export function readRuntimeValueRaw(x: any, context: any = x): RuntimeValueRaw {
     switch (x) {
       case 'Unset':
         return { kind: 'Unset' }
+      case 'NotOverridden':
+        return { kind: 'NotOverridden' }
       case 'Empty':
         return { kind: 'Empty' }
       default:

--- a/src/generated/catala_types.ts
+++ b/src/generated/catala_types.ts
@@ -40,10 +40,15 @@ export type StructDeclaration = {
   fields: Map<string, Typ>;
 }
 
+export type ScopeInput = {
+  typ: Typ;
+  is_context: boolean;
+}
+
 export type ScopeDef = {
   name: string;
   module_name: string;
-  inputs: Map<string, Typ>;
+  inputs: Map<string, ScopeInput>;
   outputs: Map<string, Typ>;
   module_deps: string[];
 }
@@ -373,11 +378,25 @@ export function readStructDeclaration(x: any, context: any = x): StructDeclarati
   };
 }
 
+export function writeScopeInput(x: ScopeInput, context: any = x): any {
+  return {
+    'typ': _atd_write_required_field('ScopeInput', 'typ', writeTyp, x.typ, x),
+    'is_context': _atd_write_required_field('ScopeInput', 'is_context', _atd_write_bool, x.is_context, x),
+  };
+}
+
+export function readScopeInput(x: any, context: any = x): ScopeInput {
+  return {
+    typ: _atd_read_required_field('ScopeInput', 'typ', readTyp, x['typ'], x),
+    is_context: _atd_read_required_field('ScopeInput', 'is_context', _atd_read_bool, x['is_context'], x),
+  };
+}
+
 export function writeScopeDef(x: ScopeDef, context: any = x): any {
   return {
     'name': _atd_write_required_field('ScopeDef', 'name', _atd_write_string, x.name, x),
     'module_name': _atd_write_required_field('ScopeDef', 'module_name', _atd_write_string, x.module_name, x),
-    'inputs': _atd_write_required_field('ScopeDef', 'inputs', _atd_write_assoc_map_to_object(writeTyp), x.inputs, x),
+    'inputs': _atd_write_required_field('ScopeDef', 'inputs', _atd_write_assoc_map_to_object(writeScopeInput), x.inputs, x),
     'outputs': _atd_write_required_field('ScopeDef', 'outputs', _atd_write_assoc_map_to_object(writeTyp), x.outputs, x),
     'module_deps': _atd_write_required_field('ScopeDef', 'module_deps', _atd_write_array(_atd_write_string), x.module_deps, x),
   };
@@ -387,7 +406,7 @@ export function readScopeDef(x: any, context: any = x): ScopeDef {
   return {
     name: _atd_read_required_field('ScopeDef', 'name', _atd_read_string, x['name'], x),
     module_name: _atd_read_required_field('ScopeDef', 'module_name', _atd_read_string, x['module_name'], x),
-    inputs: _atd_read_required_field('ScopeDef', 'inputs', _atd_read_assoc_object_into_map(readTyp), x['inputs'], x),
+    inputs: _atd_read_required_field('ScopeDef', 'inputs', _atd_read_assoc_object_into_map(readScopeInput), x['inputs'], x),
     outputs: _atd_read_required_field('ScopeDef', 'outputs', _atd_read_assoc_object_into_map(readTyp), x['outputs'], x),
     module_deps: _atd_read_required_field('ScopeDef', 'module_deps', _atd_read_array(_atd_read_string), x['module_deps'], x),
   };

--- a/src/generated/catala_types.ts
+++ b/src/generated/catala_types.ts
@@ -185,6 +185,7 @@ export type ConfirmAction =
 | { kind: 'DeleteArrayElement' }
 | { kind: 'DeleteAssertion' }
 | { kind: 'RunTestWithUnsetValues' }
+| { kind: 'ResetContextVar' }
 
 export type ConfirmRequest = {
   id: number /*int*/;
@@ -885,6 +886,8 @@ export function writeConfirmAction(x: ConfirmAction, context: any = x): any {
       return 'DeleteAssertion'
     case 'RunTestWithUnsetValues':
       return 'RunTestWithUnsetValues'
+    case 'ResetContextVar':
+      return 'ResetContextVar'
   }
 }
 
@@ -896,6 +899,8 @@ export function readConfirmAction(x: any, context: any = x): ConfirmAction {
       return { kind: 'DeleteAssertion' }
     case 'RunTestWithUnsetValues':
       return { kind: 'RunTestWithUnsetValues' }
+    case 'ResetContextVar':
+      return { kind: 'ResetContextVar' }
     default:
       _atd_bad_json('ConfirmAction', x, context)
       throw new Error('impossible')

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -17,7 +17,7 @@ const messages = {
     deleteArrayElementConfirmation: 'Delete this element?',
     deleteAssertionConfirmation: 'Delete this assertion?',
     resetContextVarConfirmation:
-      'Reset this context variable to its computed default? The current value will be lost.',
+      'Remove the override for this context variable? The current value will be lost.',
     resetContextVarButton: 'Reset',
     deleteButton: 'Delete',
     runAnywayButton: 'Run anyway',
@@ -40,7 +40,7 @@ const messages = {
     deleteArrayElementConfirmation: 'Supprimer cet élément ?',
     deleteAssertionConfirmation: 'Supprimer cette assertion ?',
     resetContextVarConfirmation:
-      'Réinitialiser cette variable de contexte à sa valeur par défaut calculée ? La valeur actuelle sera perdue.',
+      'Supprimer la redéfinition de cette variable de contexte ? La valeur actuelle sera perdue.',
     resetContextVarButton: 'Réinitialiser',
     deleteButton: 'Supprimer',
     runAnywayButton: 'Lancer quand même',

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -16,6 +16,9 @@ const messages = {
     continue: 'Continue',
     deleteArrayElementConfirmation: 'Delete this element?',
     deleteAssertionConfirmation: 'Delete this assertion?',
+    resetContextVarConfirmation:
+      'Reset this context variable to its computed default? The current value will be lost.',
+    resetContextVarButton: 'Reset',
     deleteButton: 'Delete',
     runAnywayButton: 'Run anyway',
     true: 'true',
@@ -36,6 +39,9 @@ const messages = {
     continue: 'Continuer',
     deleteArrayElementConfirmation: 'Supprimer cet élément ?',
     deleteAssertionConfirmation: 'Supprimer cette assertion ?',
+    resetContextVarConfirmation:
+      'Réinitialiser cette variable de contexte à sa valeur par défaut calculée ? La valeur actuelle sera perdue.',
+    resetContextVarButton: 'Réinitialiser',
     deleteButton: 'Supprimer',
     runAnywayButton: 'Lancer quand même',
     true: 'vrai',

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -64,8 +64,8 @@
   "arrayEditor.switchToTableView": "Switch to table view",
   "tableView.value": "Value",
   "combobox.noMatches": "No matches",
-  "testEditor.contextVarTitle": "Context variable: uses its computed default when not overridden",
-  "testEditor.usingComputedDefault": "Using computed default",
+  "testEditor.contextVarTitle": "Context variable: uses its computed value when not overridden",
+  "testEditor.usingComputedDefault": "Using computed value",
   "testEditor.override": "Override",
-  "testEditor.resetToDefault": "Reset to computed default"
+  "testEditor.resetToDefault": "Remove override"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -63,5 +63,9 @@
   "tableView.switchToTreeView": "Switch to card view",
   "arrayEditor.switchToTableView": "Switch to table view",
   "tableView.value": "Value",
-  "combobox.noMatches": "No matches"
+  "combobox.noMatches": "No matches",
+  "testEditor.contextVarTitle": "Context variable: uses its computed default when not overridden",
+  "testEditor.usingComputedDefault": "Using computed default",
+  "testEditor.override": "Override",
+  "testEditor.resetToDefault": "Reset to computed default"
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -63,5 +63,9 @@
   "tableView.switchToTreeView": "Passer en vue carte",
   "arrayEditor.switchToTableView": "Passer en vue tableau",
   "tableView.value": "Valeur",
-  "combobox.noMatches": "Aucun résultat"
+  "combobox.noMatches": "Aucun résultat",
+  "testEditor.contextVarTitle": "Variable de contexte : utilise sa valeur par défaut calculée si elle n'est pas redéfinie",
+  "testEditor.usingComputedDefault": "Valeur par défaut calculée",
+  "testEditor.override": "Remplacer",
+  "testEditor.resetToDefault": "Réinitialiser à la valeur par défaut"
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -64,8 +64,8 @@
   "arrayEditor.switchToTableView": "Passer en vue tableau",
   "tableView.value": "Valeur",
   "combobox.noMatches": "Aucun résultat",
-  "testEditor.contextVarTitle": "Variable de contexte : utilise sa valeur par défaut calculée si elle n'est pas redéfinie",
-  "testEditor.usingComputedDefault": "Valeur par défaut calculée",
+  "testEditor.contextVarTitle": "Variable de contexte : utilise sa valeur calculée si elle n'est pas redéfinie",
+  "testEditor.usingComputedDefault": "Valeur calculée",
   "testEditor.override": "Remplacer",
-  "testEditor.resetToDefault": "Réinitialiser à la valeur par défaut"
+  "testEditor.resetToDefault": "Supprimer la redéfinition"
 }

--- a/src/scope-editor/ScopeInputEditor.tsx
+++ b/src/scope-editor/ScopeInputEditor.tsx
@@ -259,6 +259,7 @@ function ScopeInputComponent(props: PropsInputComp): ReactElement {
           </h2>
           <TestInputsEditor
             test_inputs={props.test.test_inputs}
+            tested_scope={props.test.tested_scope}
             onTestInputsChange={onTestInputsChange}
           />
         </div>

--- a/src/styles/test-editor.css
+++ b/src/styles/test-editor.css
@@ -262,3 +262,64 @@
 .test-title-input:focus + .test-title-edit-icon {
   opacity: 0.6;
 }
+
+/* Context variable label wrapper */
+.context-var-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+/* Context variable badge */
+.context-var-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4em;
+  height: 1.4em;
+  border-radius: 50%;
+  background-color: #b8722a;
+  color: #fff;
+  font-size: 0.75em;
+  font-weight: 700;
+  flex-shrink: 0;
+  cursor: help;
+  user-select: none;
+}
+
+/* Placeholder shown when a context var is using its computed default */
+.context-var-placeholder {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+}
+
+.context-var-default-text {
+  font-style: italic;
+  opacity: 0.5;
+  font-size: 0.9em;
+}
+
+/* Wrapper for an active context var override (editor + reset button) */
+.context-var-editor {
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.context-var-reset-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--vscode-foreground);
+  opacity: 0.5;
+  font-size: 1.1em;
+  padding: 2px 4px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.context-var-reset-btn:hover {
+  opacity: 1;
+}

--- a/src/styles/test-editor.css
+++ b/src/styles/test-editor.css
@@ -304,7 +304,7 @@
 /* Wrapper for an active context var override (editor + reset button) */
 .context-var-editor {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 4px;
 }
 
@@ -314,9 +314,7 @@
   cursor: pointer;
   color: var(--vscode-foreground);
   opacity: 0.5;
-  font-size: 1.1em;
   padding: 2px 4px;
-  line-height: 1;
   flex-shrink: 0;
 }
 

--- a/src/test-case-editor/TestEditor.tsx
+++ b/src/test-case-editor/TestEditor.tsx
@@ -93,7 +93,7 @@ export default function TestEditor(props: Props): ReactElement {
   };
 
   const runWithUnsetCheck = async (): Promise<void> => {
-    if (hasUnsetInTest(props.test)) {
+    if (hasUnsetInTest(props.test, { testedScope: props.test.tested_scope })) {
       scrollToFirstUnset();
       const confirmed = await confirm('RunTestWithUnsetValues');
       if (!confirmed) return;
@@ -102,7 +102,7 @@ export default function TestEditor(props: Props): ReactElement {
   };
 
   const resetWithUnsetCheck = async (): Promise<void> => {
-    if (hasUnsetInTest(props.test)) {
+    if (hasUnsetInTest(props.test, { testedScope: props.test.tested_scope })) {
       scrollToFirstUnset();
       const confirmed = await confirm('RunTestWithUnsetValues');
       if (!confirmed) return;
@@ -162,6 +162,7 @@ export default function TestEditor(props: Props): ReactElement {
           </h2>
           <TestInputsEditor
             test_inputs={props.test.test_inputs}
+            tested_scope={props.test.tested_scope}
             onTestInputsChange={onTestInputsChange}
           />
         </div>

--- a/src/test-case-editor/TestEditor.tsx
+++ b/src/test-case-editor/TestEditor.tsx
@@ -93,7 +93,7 @@ export default function TestEditor(props: Props): ReactElement {
   };
 
   const runWithUnsetCheck = async (): Promise<void> => {
-    if (hasUnsetInTest(props.test, { testedScope: props.test.tested_scope })) {
+    if (hasUnsetInTest(props.test)) {
       scrollToFirstUnset();
       const confirmed = await confirm('RunTestWithUnsetValues');
       if (!confirmed) return;
@@ -102,7 +102,7 @@ export default function TestEditor(props: Props): ReactElement {
   };
 
   const resetWithUnsetCheck = async (): Promise<void> => {
-    if (hasUnsetInTest(props.test, { testedScope: props.test.tested_scope })) {
+    if (hasUnsetInTest(props.test)) {
       scrollToFirstUnset();
       const confirmed = await confirm('RunTestWithUnsetValues');
       if (!confirmed) return;

--- a/src/test-case-editor/TestInputsEditor.tsx
+++ b/src/test-case-editor/TestInputsEditor.tsx
@@ -33,14 +33,6 @@ export default function TestInputsEditor(props: Props): ReactElement {
       const showPlaceholder = isContext && !overriding.has(inputName);
 
       function onTestInputChange(newValue: TestIo): void {
-        // When a context var override is cleared back to Unset, revert to placeholder
-        if (isContext && newValue.value?.value.value.kind === 'Unset') {
-          setOverriding((prev) => {
-            const next = new Set(prev);
-            next.delete(inputName);
-            return next;
-          });
-        }
         props.onTestInputsChange(
           new Map([...props.test_inputs, [inputName, newValue]])
         );

--- a/src/test-case-editor/TestInputsEditor.tsx
+++ b/src/test-case-editor/TestInputsEditor.tsx
@@ -8,6 +8,84 @@ import ValueEditor, {
 import { CompositeEditor, type EditorItem } from '../editors/CompositeEditor';
 import { confirm } from '../messaging/confirm';
 
+type InputFieldProps = {
+  inputName: string;
+  testIo: TestIo;
+  isContext: boolean;
+  onTestInputChange(newValue: TestIo): void;
+};
+
+function InputField({
+  inputName,
+  testIo,
+  isContext,
+  onTestInputChange,
+}: InputFieldProps): ReactElement {
+  const intl = useIntl();
+  // Context vars have a computed default (Unset); overriding means the user
+  // has chosen to supply an explicit value instead.
+  const [overriding, setOverriding] = useState(
+    () => !isContext || testIo.value?.value.value.kind !== 'Unset'
+  );
+
+  function startOverride(): void {
+    setOverriding(true);
+    onTestInputChange({
+      ...testIo,
+      value: { value: getDefaultValue(testIo.typ), pos: undefined },
+    });
+  }
+
+  async function resetToDefault(): Promise<void> {
+    const hasData = testIo.value?.value.value.kind !== 'Unset';
+    if (hasData) {
+      const confirmed = await confirm('ResetContextVar');
+      if (!confirmed) return;
+    }
+    setOverriding(false);
+    onTestInputChange({
+      ...testIo,
+      value: {
+        value: createRuntimeValue({ kind: 'Unset' }),
+        pos: undefined,
+      },
+    });
+  }
+
+  if (!overriding) {
+    return (
+      <div className="context-var-placeholder">
+        <span className="context-var-default-text">
+          {intl.formatMessage({ id: 'testEditor.usingComputedDefault' })}
+        </span>
+        <button className="button-action-dvp body-b3" onClick={startOverride}>
+          {intl.formatMessage({ id: 'testEditor.override' })}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={isContext ? 'context-var-editor' : undefined}>
+      <ValueEditor
+        testIO={testIo}
+        onValueChange={onTestInputChange}
+        currentPath={[{ kind: 'StructField', value: inputName }]}
+        diffs={[]}
+      />
+      {isContext && (
+        <button
+          className="context-var-reset-btn"
+          onClick={resetToDefault}
+          title={intl.formatMessage({ id: 'testEditor.resetToDefault' })}
+        >
+          <span className="codicon codicon-trash"></span>
+        </button>
+      )}
+    </div>
+  );
+}
+
 type Props = {
   test_inputs: TestInputs;
   tested_scope: ScopeDef;
@@ -17,57 +95,15 @@ type Props = {
 export default function TestInputsEditor(props: Props): ReactElement {
   const intl = useIntl();
 
-  // Context vars that already have a non-Unset value start in override mode
-  const [overriding, setOverriding] = useState<Set<string>>(
-    () =>
-      new Set(
-        Array.from(props.test_inputs.entries())
-          .filter(([name, io]) => {
-            const si = props.tested_scope.inputs.get(name);
-            return si?.is_context && io.value?.value.value.kind !== 'Unset';
-          })
-          .map(([name]) => name)
-      )
-  );
-
   const editorItems: EditorItem[] = Array.from(props.test_inputs.entries()).map(
     ([inputName, testIo]) => {
       const isContext =
         props.tested_scope.inputs.get(inputName)?.is_context ?? false;
-      const showPlaceholder = isContext && !overriding.has(inputName);
 
       function onTestInputChange(newValue: TestIo): void {
         props.onTestInputsChange(
           new Map([...props.test_inputs, [inputName, newValue]])
         );
-      }
-
-      function startOverride(): void {
-        setOverriding((prev) => new Set([...prev, inputName]));
-        onTestInputChange({
-          ...testIo,
-          value: { value: getDefaultValue(testIo.typ), pos: undefined },
-        });
-      }
-
-      async function resetToDefault(): Promise<void> {
-        const hasData = testIo.value?.value.value.kind !== 'Unset';
-        if (hasData) {
-          const confirmed = await confirm('ResetContextVar');
-          if (!confirmed) return;
-        }
-        setOverriding((prev) => {
-          const next = new Set(prev);
-          next.delete(inputName);
-          return next;
-        });
-        onTestInputChange({
-          ...testIo,
-          value: {
-            value: createRuntimeValue({ kind: 'Unset' }),
-            pos: undefined,
-          },
-        });
       }
 
       const label = isContext ? (
@@ -85,49 +121,18 @@ export default function TestInputsEditor(props: Props): ReactElement {
         inputName
       );
 
-      const editor = showPlaceholder ? (
-        <div className="context-var-placeholder">
-          <span className="context-var-default-text">
-            {intl.formatMessage({
-              id: 'testEditor.usingComputedDefault',
-              defaultMessage: 'Using computed default',
-            })}
-          </span>
-          <button className="button-action-dvp body-b3" onClick={startOverride}>
-            {intl.formatMessage({
-              id: 'testEditor.override',
-              defaultMessage: 'Override',
-            })}
-          </button>
-        </div>
-      ) : (
-        <div className={isContext ? 'context-var-editor' : undefined}>
-          <ValueEditor
-            testIO={testIo}
-            onValueChange={onTestInputChange}
-            currentPath={[{ kind: 'StructField', value: inputName }]}
-            diffs={[]}
-          />
-          {isContext && (
-            <button
-              className="context-var-reset-btn"
-              onClick={resetToDefault}
-              title={intl.formatMessage({
-                id: 'testEditor.resetToDefault',
-                defaultMessage: 'Reset to computed default',
-              })}
-            >
-              <span className="codicon codicon-trash"></span>
-            </button>
-          )}
-        </div>
-      );
-
       return {
         key: inputName,
         label,
         type: testIo.typ,
-        editor,
+        editor: (
+          <InputField
+            inputName={inputName}
+            testIo={testIo}
+            isContext={isContext}
+            onTestInputChange={onTestInputChange}
+          />
+        ),
       };
     }
   );

--- a/src/test-case-editor/TestInputsEditor.tsx
+++ b/src/test-case-editor/TestInputsEditor.tsx
@@ -1,7 +1,10 @@
 import { type ReactElement, useState } from 'react';
 import { useIntl } from 'react-intl';
 import type { TestInputs, TestIo, ScopeDef } from '../generated/catala_types';
-import ValueEditor, { getDefaultValue } from '../editors/ValueEditors';
+import ValueEditor, {
+  getDefaultValue,
+  createRuntimeValue,
+} from '../editors/ValueEditors';
 import { CompositeEditor, type EditorItem } from '../editors/CompositeEditor';
 
 type Props = {
@@ -40,6 +43,10 @@ export default function TestInputsEditor(props: Props): ReactElement {
 
       function startOverride(): void {
         setOverriding((prev) => new Set([...prev, inputName]));
+        onTestInputChange({
+          ...testIo,
+          value: { value: getDefaultValue(testIo.typ), pos: undefined },
+        });
       }
 
       function resetToDefault(): void {
@@ -50,7 +57,10 @@ export default function TestInputsEditor(props: Props): ReactElement {
         });
         onTestInputChange({
           ...testIo,
-          value: { value: getDefaultValue(testIo.typ), pos: undefined },
+          value: {
+            value: createRuntimeValue({ kind: 'Unset' }),
+            pos: undefined,
+          },
         });
       }
 

--- a/src/test-case-editor/TestInputsEditor.tsx
+++ b/src/test-case-editor/TestInputsEditor.tsx
@@ -6,6 +6,7 @@ import ValueEditor, {
   createRuntimeValue,
 } from '../editors/ValueEditors';
 import { CompositeEditor, type EditorItem } from '../editors/CompositeEditor';
+import { confirm } from '../messaging/confirm';
 
 type Props = {
   test_inputs: TestInputs;
@@ -49,7 +50,12 @@ export default function TestInputsEditor(props: Props): ReactElement {
         });
       }
 
-      function resetToDefault(): void {
+      async function resetToDefault(): Promise<void> {
+        const hasData = testIo.value?.value.value.kind !== 'Unset';
+        if (hasData) {
+          const confirmed = await confirm('ResetContextVar');
+          if (!confirmed) return;
+        }
         setOverriding((prev) => {
           const next = new Set(prev);
           next.delete(inputName);

--- a/src/test-case-editor/TestInputsEditor.tsx
+++ b/src/test-case-editor/TestInputsEditor.tsx
@@ -22,10 +22,9 @@ function InputField({
   onTestInputChange,
 }: InputFieldProps): ReactElement {
   const intl = useIntl();
-  // Context vars have a computed default (Unset); overriding means the user
-  // has chosen to supply an explicit value instead.
+  // false iff the context var is NotOverridden (using scope-computed default)
   const [overriding, setOverriding] = useState(
-    () => !isContext || testIo.value?.value.value.kind !== 'Unset'
+    () => testIo.value?.value.value.kind !== 'NotOverridden'
   );
 
   function startOverride(): void {
@@ -37,7 +36,7 @@ function InputField({
   }
 
   async function resetToDefault(): Promise<void> {
-    const hasData = testIo.value?.value.value.kind !== 'Unset';
+    const hasData = testIo.value?.value.value.kind !== 'NotOverridden';
     if (hasData) {
       const confirmed = await confirm('ResetContextVar');
       if (!confirmed) return;
@@ -46,7 +45,7 @@ function InputField({
     onTestInputChange({
       ...testIo,
       value: {
-        value: createRuntimeValue({ kind: 'Unset' }),
+        value: createRuntimeValue({ kind: 'NotOverridden' }),
         pos: undefined,
       },
     });

--- a/src/test-case-editor/TestInputsEditor.tsx
+++ b/src/test-case-editor/TestInputsEditor.tsx
@@ -1,35 +1,125 @@
-import { type ReactElement } from 'react';
-import type { TestInputs, TestIo } from '../generated/catala_types';
-import ValueEditor from '../editors/ValueEditors';
+import { type ReactElement, useState } from 'react';
+import { useIntl } from 'react-intl';
+import type { TestInputs, TestIo, ScopeDef } from '../generated/catala_types';
+import ValueEditor, { getDefaultValue } from '../editors/ValueEditors';
 import { CompositeEditor, type EditorItem } from '../editors/CompositeEditor';
 
 type Props = {
   test_inputs: TestInputs;
+  tested_scope: ScopeDef;
   onTestInputsChange(newValue: TestInputs): void;
 };
 
 export default function TestInputsEditor(props: Props): ReactElement {
-  // Create editor items for CompositeEditor
+  const intl = useIntl();
+
+  // Context vars that already have a non-Unset value start in override mode
+  const [overriding, setOverriding] = useState<Set<string>>(
+    () =>
+      new Set(
+        Array.from(props.test_inputs.entries())
+          .filter(([name, io]) => {
+            const si = props.tested_scope.inputs.get(name);
+            return si?.is_context && io.value?.value.value.kind !== 'Unset';
+          })
+          .map(([name]) => name)
+      )
+  );
+
   const editorItems: EditorItem[] = Array.from(props.test_inputs.entries()).map(
     ([inputName, testIo]) => {
+      const isContext =
+        props.tested_scope.inputs.get(inputName)?.is_context ?? false;
+      const showPlaceholder = isContext && !overriding.has(inputName);
+
       function onTestInputChange(newValue: TestIo): void {
+        // When a context var override is cleared back to Unset, revert to placeholder
+        if (isContext && newValue.value?.value.value.kind === 'Unset') {
+          setOverriding((prev) => {
+            const next = new Set(prev);
+            next.delete(inputName);
+            return next;
+          });
+        }
         props.onTestInputsChange(
           new Map([...props.test_inputs, [inputName, newValue]])
         );
       }
 
-      return {
-        key: inputName,
-        label: inputName,
-        type: testIo.typ,
-        editor: (
+      function startOverride(): void {
+        setOverriding((prev) => new Set([...prev, inputName]));
+      }
+
+      function resetToDefault(): void {
+        setOverriding((prev) => {
+          const next = new Set(prev);
+          next.delete(inputName);
+          return next;
+        });
+        onTestInputChange({
+          ...testIo,
+          value: { value: getDefaultValue(testIo.typ), pos: undefined },
+        });
+      }
+
+      const label = isContext ? (
+        <span className="context-var-label">
+          <span
+            className="context-var-badge"
+            title={intl.formatMessage({ id: 'testEditor.contextVarTitle' })}
+            aria-hidden="true"
+          >
+            C
+          </span>
+          {inputName}
+        </span>
+      ) : (
+        inputName
+      );
+
+      const editor = showPlaceholder ? (
+        <div className="context-var-placeholder">
+          <span className="context-var-default-text">
+            {intl.formatMessage({
+              id: 'testEditor.usingComputedDefault',
+              defaultMessage: 'Using computed default',
+            })}
+          </span>
+          <button className="button-action-dvp body-b3" onClick={startOverride}>
+            {intl.formatMessage({
+              id: 'testEditor.override',
+              defaultMessage: 'Override',
+            })}
+          </button>
+        </div>
+      ) : (
+        <div className={isContext ? 'context-var-editor' : undefined}>
           <ValueEditor
             testIO={testIo}
             onValueChange={onTestInputChange}
             currentPath={[{ kind: 'StructField', value: inputName }]}
             diffs={[]}
           />
-        ),
+          {isContext && (
+            <button
+              className="context-var-reset-btn"
+              onClick={resetToDefault}
+              title={intl.formatMessage({
+                id: 'testEditor.resetToDefault',
+                defaultMessage: 'Reset to computed default',
+              })}
+            >
+              ×
+            </button>
+          )}
+        </div>
+      );
+
+      return {
+        key: inputName,
+        label,
+        type: testIo.typ,
+        editor,
       };
     }
   );

--- a/src/test-case-editor/TestInputsEditor.tsx
+++ b/src/test-case-editor/TestInputsEditor.tsx
@@ -101,7 +101,7 @@ export default function TestInputsEditor(props: Props): ReactElement {
                 defaultMessage: 'Reset to computed default',
               })}
             >
-              ×
+              <span className="codicon codicon-trash"></span>
             </button>
           )}
         </div>

--- a/test-case-parser/examples/context.catala_en
+++ b/test-case-parser/examples/context.catala_en
@@ -12,7 +12,6 @@ declaration structure Item:
 
 declaration scope CArray:
   input x content integer
-  input tags content list of integer
   context items content list of Item
   context output total content integer
 ```

--- a/test-case-parser/examples/context.catala_en
+++ b/test-case-parser/examples/context.catala_en
@@ -12,6 +12,7 @@ declaration structure Item:
 
 declaration scope CArray:
   input x content integer
+  input tags content list of integer
   context items content list of Item
   context output total content integer
 ```

--- a/test-case-parser/examples/context.catala_en
+++ b/test-case-parser/examples/context.catala_en
@@ -1,0 +1,14 @@
+> Module Context
+
+```catala-metadata
+declaration scope C:
+  input x content integer
+  context y content integer
+  context output z content integer
+```
+
+```catala
+scope C:
+  definition y equals x + 10
+  definition z equals y * 2
+```

--- a/test-case-parser/examples/context.catala_en
+++ b/test-case-parser/examples/context.catala_en
@@ -5,10 +5,23 @@ declaration scope C:
   input x content integer
   context y content integer
   context output z content integer
+
+declaration structure Item:
+  data id content integer
+  data amount content money
+
+declaration scope CArray:
+  input x content integer
+  context items content list of Item
+  context output total content integer
 ```
 
 ```catala
 scope C:
   definition y equals x + 10
   definition z equals y * 2
+
+scope CArray:
+  definition items equals []
+  definition total equals (number of items) + x
 ```

--- a/test-case-parser/examples/test_case_context.catala_en
+++ b/test-case-parser/examples/test_case_context.catala_en
@@ -7,7 +7,7 @@
 #[testcase.test_title = "C"]
 declaration scope C_test:
   output c scope Context.C
-  
+
 ```
 
 ```catala

--- a/test-case-parser/examples/test_case_context.catala_en
+++ b/test-case-parser/examples/test_case_context.catala_en
@@ -1,0 +1,18 @@
+> Using Context
+
+```catala-metadata
+#[test]
+#[testcase.testui]
+#[testcase.test_description = ""]
+#[testcase.test_title = "C"]
+declaration scope C_test:
+  output c scope Context.C
+  
+```
+
+```catala
+scope C_test:
+  definition c.x equals 2
+  definition c.z equals 43
+  assertion (c.z = 43)
+```

--- a/test-case-parser/examples/test_case_context_array_no_override.catala_en
+++ b/test-case-parser/examples/test_case_context_array_no_override.catala_en
@@ -13,7 +13,10 @@ declaration scope CArray_no_override_test:
 ```catala
 scope CArray_no_override_test:
   definition c_array.x equals 5
-  definition c_array.tags equals []
+  definition c_array.tags equals
+    [#[testcase.uid = "470d701b-d273-4d3e-8102-9ea2446d36dd"]
+     3456; #[testcase.uid = "26e7fdf7-508c-4cf6-a63f-444c2c41d8df"]
+     345]
   definition c_array.total equals 33
   assertion (c_array.total = 0)
 ```

--- a/test-case-parser/examples/test_case_context_array_no_override.catala_en
+++ b/test-case-parser/examples/test_case_context_array_no_override.catala_en
@@ -3,20 +3,15 @@
 ```catala-metadata
 #[test]
 #[testcase.testui]
-#[testcase.test_description = "Array context var not overridden: items uses computed default (empty list), total should be 0"]
+#[testcase.test_description = "Array context var not overridden: items uses computed default (empty list), total should equal x = 5"]
 #[testcase.test_title = "CArray without override"]
 declaration scope CArray_no_override_test:
   output c_array scope Context.CArray
-  
+
 ```
 
 ```catala
 scope CArray_no_override_test:
   definition c_array.x equals 5
-  definition c_array.tags equals
-    [#[testcase.uid = "470d701b-d273-4d3e-8102-9ea2446d36dd"]
-     3456; #[testcase.uid = "26e7fdf7-508c-4cf6-a63f-444c2c41d8df"]
-     345]
-  definition c_array.total equals 33
-  assertion (c_array.total = 0)
+  assertion (c_array.total = 5)
 ```

--- a/test-case-parser/examples/test_case_context_array_no_override.catala_en
+++ b/test-case-parser/examples/test_case_context_array_no_override.catala_en
@@ -13,7 +13,7 @@ declaration scope CArray_no_override_test:
 ```catala
 scope CArray_no_override_test:
   definition c_array.x equals 5
-  definition c_array.items equals []
+  definition c_array.tags equals []
   definition c_array.total equals 33
   assertion (c_array.total = 0)
 ```

--- a/test-case-parser/examples/test_case_context_array_no_override.catala_en
+++ b/test-case-parser/examples/test_case_context_array_no_override.catala_en
@@ -13,5 +13,13 @@ declaration scope CArray_no_override_test:
 ```catala
 scope CArray_no_override_test:
   definition c_array.x equals 5
+  definition c_array.items equals
+    [#[testcase.uid = "fb152135-959c-47d6-bb7b-e25c8801d8d6"]
+     Context.Item {
+       -- id: #[testcase.uid = "fb152135-959c-47d6-bb7b-e25c8801d8d6"]
+       3
+       -- amount: $2.00
+     }]
+  definition c_array.total equals 3
   assertion (c_array.total = 5)
 ```

--- a/test-case-parser/examples/test_case_context_array_no_override.catala_en
+++ b/test-case-parser/examples/test_case_context_array_no_override.catala_en
@@ -1,0 +1,19 @@
+> Using Context
+
+```catala-metadata
+#[test]
+#[testcase.testui]
+#[testcase.test_description = "Array context var not overridden: items uses computed default (empty list), total should be 0"]
+#[testcase.test_title = "CArray without override"]
+declaration scope CArray_no_override_test:
+  output c_array scope Context.CArray
+  
+```
+
+```catala
+scope CArray_no_override_test:
+  definition c_array.x equals 5
+  definition c_array.items equals []
+  definition c_array.total equals 33
+  assertion (c_array.total = 0)
+```

--- a/test-case-parser/examples/test_case_context_array_override.catala_en
+++ b/test-case-parser/examples/test_case_context_array_override.catala_en
@@ -1,0 +1,21 @@
+> Using Context
+
+```catala-metadata
+#[test]
+#[testcase.testui]
+#[testcase.test_description = "Array context var overridden: items has two elements, total should be 2"]
+#[testcase.test_title = "CArray with items overridden"]
+declaration scope CArray_override_test:
+  output c scope Context.CArray
+
+```
+
+```catala
+scope CArray_override_test:
+  definition c.x equals 3
+  definition c.items equals [
+    Context.Item { -- id: 1 -- amount: $10.00 };
+    Context.Item { -- id: 2 -- amount: $20.00 }
+  ]
+  assertion (c.total = 5)
+```

--- a/test-case-parser/examples/test_case_context_array_override.catala_en
+++ b/test-case-parser/examples/test_case_context_array_override.catala_en
@@ -13,7 +13,6 @@ declaration scope CArray_override_test:
 ```catala
 scope CArray_override_test:
   definition c.x equals 3
-  definition c.tags equals [10; 20; 30]
   definition c.items equals [
     Context.Item { -- id: 1 -- amount: $10.00 };
     Context.Item { -- id: 2 -- amount: $20.00 }

--- a/test-case-parser/examples/test_case_context_array_override.catala_en
+++ b/test-case-parser/examples/test_case_context_array_override.catala_en
@@ -13,6 +13,7 @@ declaration scope CArray_override_test:
 ```catala
 scope CArray_override_test:
   definition c.x equals 3
+  definition c.tags equals [10; 20; 30]
   definition c.items equals [
     Context.Item { -- id: 1 -- amount: $10.00 };
     Context.Item { -- id: 2 -- amount: $20.00 }

--- a/test-case-parser/examples/test_case_context_no_override.catala_en
+++ b/test-case-parser/examples/test_case_context_no_override.catala_en
@@ -7,7 +7,7 @@
 #[testcase.test_title = "C"]
 declaration scope C_test:
   output c scope Context.C
-  
+
 ```
 
 ```catala

--- a/test-case-parser/examples/test_case_context_no_override.catala_en
+++ b/test-case-parser/examples/test_case_context_no_override.catala_en
@@ -1,0 +1,16 @@
+> Using Context
+
+```catala-metadata
+#[test]
+#[testcase.testui]
+#[testcase.test_description = ""]
+#[testcase.test_title = "C"]
+declaration scope C_test:
+  output c scope Context.C
+  
+```
+
+```catala
+scope C_test:
+  definition c.x equals 5
+```

--- a/test-case-parser/test_case_parser_lib.ml
+++ b/test-case-parser/test_case_parser_lib.ml
@@ -489,8 +489,12 @@ let unset_default_value (typ : O.typ) : O.value_def =
   in
   { O.value; pos = None }
 
-(** For context variables, always use Unset regardless of type: Unset means
-    "use computed default", even for arrays. *)
+(** For context variables, always use Unset regardless of type.
+    Context variables have a scope-computed default. [Unset] here means
+    "no override — let the scope compute its own value". This differs from
+    [unset_default_value], which uses [Array [||]] for array types: that
+    would generate an explicit [definition x = []] override in the test
+    output, replacing the computed default with an empty array. *)
 let context_var_default : O.value_def =
   { O.value = { O.value = O.Unset; attrs = [] }; pos = None }
 

--- a/test-case-parser/test_case_parser_lib.ml
+++ b/test-case-parser/test_case_parser_lib.ml
@@ -406,10 +406,14 @@ let scope_inputs lang decl_ctx scope =
         match fst sdef.I.scope_def_io.I.io_input with
         | Catala_runtime.NoInput -> acc
         | Catala_runtime.OnlyInput ->
-          (ScopeVar.to_string v, get_typ lang decl_ctx sdef.I.scope_def_typ)
+          ( ScopeVar.to_string v,
+            O.{ typ = get_typ lang decl_ctx sdef.I.scope_def_typ;
+                is_context = false } )
           :: acc
         | Catala_runtime.Reentrant ->
-          (ScopeVar.to_string v, get_typ lang decl_ctx sdef.I.scope_def_typ)
+          ( ScopeVar.to_string v,
+            O.{ typ = get_typ lang decl_ctx sdef.I.scope_def_typ;
+                is_context = true } )
           :: acc))
     scope.I.scope_defs []
   |> List.rev
@@ -510,7 +514,8 @@ let get_scope_test
   in
   let test_inputs =
     List.map
-      (fun (v, typ) -> v, { O.typ; value = Some (unset_default_value typ) })
+      (fun (v, (si : O.scope_input)) ->
+        v, { O.typ = si.typ; value = Some (unset_default_value si.typ) })
       tested_scope.inputs
   in
   let test_outputs =
@@ -646,7 +651,11 @@ let patch_paths
   let tested_scope =
     {
       tested_scope with
-      inputs = List.map (fun (x, t) -> x, patch_typ t) tested_scope.inputs;
+      inputs =
+        List.map
+          (fun (x, (si : O.scope_input)) ->
+            x, { si with typ = patch_typ si.typ })
+          tested_scope.inputs;
       outputs = List.map (fun (x, t) -> x, patch_typ t) tested_scope.outputs;
     }
   in
@@ -690,7 +699,7 @@ let generate_test
   if with_default_values then
     let test_inputs =
       List.map
-        (fun (s, io) ->
+        (fun (s, (io : O.test_io)) ->
           ( s,
             O.
               {
@@ -775,7 +784,7 @@ let get_catala_test (prg, naming_ctx) testing_scope_name =
   in
   let test_inputs =
     List.map
-      (fun (var_str, test_in) ->
+      (fun (var_str, (test_in : O.test_io)) ->
         let var_within_origin_scope =
           Ident.Map.find var_str tested_id_var_map
         in
@@ -1063,14 +1072,29 @@ let write_catala_test ppf t lang =
   fprintf ppf "%s %s %s %s.%s@," strings.output_scope sscope_var strings.scope
     t.tested_scope.module_name t.tested_scope.name;
   fprintf ppf "@]@,```@,";
+  let inputs_by_name =
+    List.to_seq t.tested_scope.inputs |> Hashtbl.of_seq
+  in
   fprintf ppf "@,```catala@,";
   fprintf ppf "@[<v 2>%s %s:" strings.scope t.testing_scope;
   List.iter
     (fun (tvar, t_in) ->
-      fprintf ppf "@,@[<hv 2>%s %s.%s %s@ %a@]" strings.definition sscope_var
-        tvar strings.equals
-        (print_catala_value_opt ~lang)
-        t_in)
+      let is_context =
+        match Hashtbl.find_opt inputs_by_name tvar with
+        | Some (si : O.scope_input) -> si.is_context
+        | None -> false
+      in
+      let is_unset =
+        match t_in.O.value with
+        | Some { value = { value = O.Unset; _ }; _ } | None -> true
+        | _ -> false
+      in
+      if is_context && is_unset then ()
+      else
+        fprintf ppf "@,@[<hv 2>%s %s.%s %s@ %a@]" strings.definition
+          sscope_var tvar strings.equals
+          (print_catala_value_opt ~lang)
+          t_in)
     t.test_inputs;
   List.iter
     (fun (tvar, t_out) ->

--- a/test-case-parser/test_case_parser_lib.ml
+++ b/test-case-parser/test_case_parser_lib.ml
@@ -489,6 +489,11 @@ let unset_default_value (typ : O.typ) : O.value_def =
   in
   { O.value; pos = None }
 
+(** For context variables, always use Unset regardless of type: Unset means
+    "use computed default", even for arrays. *)
+let context_var_default : O.value_def =
+  { O.value = { O.value = O.Unset; attrs = [] }; pos = None }
+
 let get_scope_test
     (prg : I.program)
     (testing_scope : string)
@@ -515,7 +520,11 @@ let get_scope_test
   let test_inputs =
     List.map
       (fun (v, (si : O.scope_input)) ->
-        v, { O.typ = si.typ; value = Some (unset_default_value si.typ) })
+        let default =
+          if si.is_context then context_var_default
+          else unset_default_value si.typ
+        in
+        v, { O.typ = si.typ; value = Some default })
       tested_scope.inputs
   in
   let test_outputs =
@@ -800,8 +809,16 @@ let get_catala_test (prg, naming_ctx) testing_scope_name =
               RuleName.Map.bindings def.scope_def_rules
             with Ident.Map.Not_found _ | I.ScopeDef.Map.Not_found _ -> []
           in
+          let is_context =
+            List.assoc_opt var_str base_test.tested_scope.inputs
+            |> Option.map (fun (si : O.scope_input) -> si.is_context)
+            |> Option.value ~default:false
+          in
           match rules with
-          | [] -> Some (unset_default_value test_in.O.typ)
+          | [] ->
+            Some
+              (if is_context then context_var_default
+               else unset_default_value test_in.O.typ)
           | [(_, rule)] ->
             let e = Expr.unbox_closed rule.rule_cons in
             let value = get_value prg.program_lang prg.program_ctx e in

--- a/test-case-parser/test_case_parser_lib.ml
+++ b/test-case-parser/test_case_parser_lib.ml
@@ -489,14 +489,14 @@ let unset_default_value (typ : O.typ) : O.value_def =
   in
   { O.value; pos = None }
 
-(** For context variables, always use Unset regardless of type.
-    Context variables have a scope-computed default. [Unset] here means
-    "no override — let the scope compute its own value". This differs from
-    [unset_default_value], which uses [Array [||]] for array types: that
-    would generate an explicit [definition x = []] override in the test
-    output, replacing the computed default with an empty array. *)
+(** For context variables, use [NotOverridden] regardless of type.
+    Context variables have a scope-computed default. [NotOverridden] means
+    "no override — let the scope compute its own value". The field is omitted
+    from the JSON input sent to the runtime and from the rendered Catala test.
+    This differs from [unset_default_value], which uses [Array [||]] for array
+    types: that would generate an explicit [definition x = []] override. *)
 let context_var_default : O.value_def =
-  { O.value = { O.value = O.Unset; attrs = [] }; pos = None }
+  { O.value = { O.value = O.NotOverridden; attrs = [] }; pos = None }
 
 let get_scope_test
     (prg : I.program)
@@ -635,7 +635,7 @@ let patch_paths
    fun ({ value; attrs } as v) ->
     match value with
     | O.Bool _ | O.Money _ | O.Integer _ | O.Decimal _ | O.Date _ | O.Duration _
-    | O.Empty | O.Unset ->
+    | O.Empty | O.Unset | O.NotOverridden ->
       v
     | O.Enum (enum_decl, (cstr, rv_opt)) ->
       {
@@ -713,16 +713,23 @@ let generate_test
     let test_inputs =
       List.map
         (fun (s, (io : O.test_io)) ->
+          let is_context =
+            List.assoc_opt s test.tested_scope.inputs
+            |> Option.map (fun (si : O.scope_input) -> si.is_context)
+            |> Option.value ~default:false
+          in
           ( s,
             O.
               {
                 io with
                 value =
                   Some
-                    {
-                      value = generate_default_value prg.program_lang io.typ;
-                      pos = None;
-                    };
+                    (if is_context then context_var_default
+                     else
+                       {
+                         value = generate_default_value prg.program_lang io.typ;
+                         pos = None;
+                       });
               } ))
         test.test_inputs
     in
@@ -979,6 +986,7 @@ let rec print_catala_value ~(typ : O.typ option) ~lang ppf (v : O.runtime_value)
   print_attrs ppf v.attrs;
   match typ, v.value with
   | _, O.Unset -> pp_print_string ppf "impossible"
+  | _, O.NotOverridden -> assert false (* filtered before printing *)
   | _, O.Bool b ->
     pp_print_string ppf (if b then strings.true_str else strings.false_str)
   | _, O.Money m ->
@@ -1093,24 +1101,16 @@ let write_catala_test ppf t lang =
   fprintf ppf "%s %s %s %s.%s@," strings.output_scope sscope_var strings.scope
     t.tested_scope.module_name t.tested_scope.name;
   fprintf ppf "@]@,```@,";
-  let inputs_by_name =
-    List.to_seq t.tested_scope.inputs |> Hashtbl.of_seq
-  in
   fprintf ppf "@,```catala@,";
   fprintf ppf "@[<v 2>%s %s:" strings.scope t.testing_scope;
   List.iter
     (fun (tvar, t_in) ->
-      let is_context =
-        match Hashtbl.find_opt inputs_by_name tvar with
-        | Some (si : O.scope_input) -> si.is_context
-        | None -> false
-      in
-      let is_unset =
+      let should_skip =
         match t_in.O.value with
-        | Some { value = { value = O.Unset; _ }; _ } | None -> true
+        | Some { value = { value = O.NotOverridden; _ }; _ } -> true
         | _ -> false
       in
-      if is_context && is_unset then ()
+      if should_skip then ()
       else
         fprintf ppf "@,@[<hv 2>%s %s.%s %s@ %a@]" strings.definition
           sscope_var tvar strings.equals
@@ -1392,6 +1392,7 @@ let rec convert_atd_to_runtime_value : O.runtime_value -> Catala_runtime.Value.t
     let l = Array.map convert_atd_to_runtime_value l in
     V (Array Fun.id, l)
   | Unset -> failwith "Cannot convert 'Unset' atd value to Catala runtime value"
+  | NotOverridden -> failwith "Cannot convert 'NotOverridden' atd value to Catala runtime value"
   | Empty -> failwith "Cannot convert 'Empty' atd value to Catala runtime value"
 
 let interpret_program dcalc_prg scope_name build_term_to_interp =
@@ -1448,6 +1449,7 @@ let rec convert_to_json_input ({ value; _ } : O.runtime_value) : Yojson.Safe.t =
            fl)
     | Array l -> `List (Array.to_list l |> List.map convert_to_json_input)
     | Unset -> failwith "convert_to_json_input: cannot convert 'unset' values"
+    | NotOverridden -> failwith "convert_to_json_input: cannot convert 'NotOverridden' values"
     | Empty -> failwith "convert_to_json_input: cannot convert 'empty' values"
   in
   convert_runtime_raw value
@@ -1480,10 +1482,17 @@ let run_with_inputs
           O.Struct
             ( (* Dummy declaration *)
               { O.struct_name = StructName.to_string in_struct; fields = [] },
-              List.map
+              List.filter_map
                 (fun (field_name, { O.value; typ = _ }) ->
-                  let value = (Option.get value).value in
-                  field_name, value)
+                  let rv = (Option.get value).value in
+                  match rv.O.value with
+                  | O.NotOverridden -> None
+                  | O.Unset ->
+                    failwith
+                      (Printf.sprintf
+                         "run_with_inputs: input '%s' has Unset value"
+                         field_name)
+                  | _ -> Some (field_name, rv))
                 fields );
       }
     in
@@ -1644,10 +1653,17 @@ let serialize_inputs (scope_input : Yojson.Safe.t option) =
     let value =
       O.Struct
         ( dummy_decl,
-          List.map
+          List.filter_map
             (fun (field_name, { J.value; typ = _ }) ->
-              let value = (Option.get value).value in
-              field_name, value)
+              let rv = (Option.get value).value in
+              match rv.O.value with
+              | O.NotOverridden -> None
+              | O.Unset ->
+                failwith
+                  (Printf.sprintf
+                     "serialize_inputs: input '%s' has Unset value"
+                     field_name)
+              | _ -> Some (field_name, rv))
             fields )
     in
     let json = convert_to_json_input { value; attrs = [] } in

--- a/tests/editors/context-var-editor.spec.tsx
+++ b/tests/editors/context-var-editor.spec.tsx
@@ -70,8 +70,10 @@ describe('TestInputsEditor - context variables', () => {
     fireEvent.click(screen.getByRole('button', { name: /override/i }));
     expect(screen.queryByText(/using computed default/i)).toBeNull();
 
-    // click × → back to placeholder
-    fireEvent.click(screen.getByRole('button', { name: '×' }));
+    // click reset (trash) → back to placeholder
+    fireEvent.click(
+      screen.getByRole('button', { name: /reset to computed default/i })
+    );
     expect(screen.getByText(/using computed default/i)).toBeInTheDocument();
   });
 

--- a/tests/editors/context-var-editor.spec.tsx
+++ b/tests/editors/context-var-editor.spec.tsx
@@ -63,18 +63,16 @@ describe('TestInputsEditor - context variables', () => {
     const { container } = renderInputsEditor(makeInputs('Unset'), onChange);
 
     // y is context + unset → placeholder mode
-    expect(screen.getByText(/using computed default/i)).toBeInTheDocument();
+    expect(screen.getByText(/using computed value/i)).toBeInTheDocument();
     expect(container.querySelector('.context-var-editor')).toBeNull();
 
     // click Override → editor appears
     fireEvent.click(screen.getByRole('button', { name: /override/i }));
-    expect(screen.queryByText(/using computed default/i)).toBeNull();
+    expect(screen.queryByText(/using computed value/i)).toBeNull();
 
     // click reset (trash) → back to placeholder
-    fireEvent.click(
-      screen.getByRole('button', { name: /reset to computed default/i })
-    );
-    expect(screen.getByText(/using computed default/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /remove override/i }));
+    expect(screen.getByText(/using computed value/i)).toBeInTheDocument();
   });
 
   it('typing an invalid value in an overridden context var keeps the editor visible', () => {
@@ -82,7 +80,7 @@ describe('TestInputsEditor - context variables', () => {
     const { container } = renderInputsEditor(makeInputs(99));
 
     // sanity: no placeholder visible
-    expect(screen.queryByText(/using computed default/i)).toBeNull();
+    expect(screen.queryByText(/using computed value/i)).toBeNull();
 
     // type an invalid intermediate value
     const input = container.querySelector(
@@ -92,7 +90,7 @@ describe('TestInputsEditor - context variables', () => {
     fireEvent.change(input, { target: { value: '-' } });
 
     // the editor must still be showing (not reverted to placeholder)
-    expect(screen.queryByText(/using computed default/i)).toBeNull();
+    expect(screen.queryByText(/using computed value/i)).toBeNull();
     expect(container.querySelector('.context-var-editor')).toBeInTheDocument();
     // and the invalid indicator should be present
     expect(

--- a/tests/editors/context-var-editor.spec.tsx
+++ b/tests/editors/context-var-editor.spec.tsx
@@ -17,7 +17,7 @@ const testedScope: ScopeDef = {
   module_deps: [],
 };
 
-function makeInputs(yKind: 'Unset' | number): TestInputs {
+function makeInputs(yKind: 'NotOverridden' | number): TestInputs {
   return new Map([
     [
       'x',
@@ -34,8 +34,8 @@ function makeInputs(yKind: 'Unset' | number): TestInputs {
       {
         typ: { kind: 'TInt' },
         value:
-          yKind === 'Unset'
-            ? { value: { value: { kind: 'Unset' } }, pos: undefined }
+          yKind === 'NotOverridden'
+            ? { value: { value: { kind: 'NotOverridden' } }, pos: undefined }
             : {
                 value: { value: { kind: 'Int', value: yKind } },
                 pos: undefined,
@@ -60,7 +60,7 @@ function renderInputsEditor(inputs: TestInputs, onchange = vi.fn()) {
 describe('TestInputsEditor - context variables', () => {
   it('shows placeholder for unset context var, Override button switches to editor, × resets', () => {
     const onChange = vi.fn();
-    const { container } = renderInputsEditor(makeInputs('Unset'), onChange);
+    const { container } = renderInputsEditor(makeInputs('NotOverridden'), onChange);
 
     // y is context + unset → placeholder mode
     expect(screen.getByText(/using computed value/i)).toBeInTheDocument();

--- a/tests/editors/context-var-editor.spec.tsx
+++ b/tests/editors/context-var-editor.spec.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import enMessages from '../../src/locales/en.json';
+import TestInputsEditor from '../../src/test-case-editor/TestInputsEditor';
+import type { ScopeDef, TestInputs } from '../../src/generated/catala_types';
+
+const testedScope: ScopeDef = {
+  name: 'C',
+  module_name: 'Context',
+  inputs: new Map([
+    ['x', { typ: { kind: 'TInt' }, is_context: false }],
+    ['y', { typ: { kind: 'TInt' }, is_context: true }],
+  ]),
+  outputs: new Map(),
+  module_deps: [],
+};
+
+function makeInputs(yKind: 'Unset' | number): TestInputs {
+  return new Map([
+    [
+      'x',
+      {
+        typ: { kind: 'TInt' },
+        value: {
+          value: { value: { kind: 'Int', value: 5 } },
+          pos: undefined,
+        },
+      },
+    ],
+    [
+      'y',
+      {
+        typ: { kind: 'TInt' },
+        value:
+          yKind === 'Unset'
+            ? { value: { value: { kind: 'Unset' } }, pos: undefined }
+            : {
+                value: { value: { kind: 'Int', value: yKind } },
+                pos: undefined,
+              },
+      },
+    ],
+  ]);
+}
+
+function renderInputsEditor(inputs: TestInputs, onchange = vi.fn()) {
+  return render(
+    <IntlProvider locale="en" messages={enMessages}>
+      <TestInputsEditor
+        test_inputs={inputs}
+        tested_scope={testedScope}
+        onTestInputsChange={onchange}
+      />
+    </IntlProvider>
+  );
+}
+
+describe('TestInputsEditor - context variables', () => {
+  it('shows placeholder for unset context var, Override button switches to editor, × resets', () => {
+    const onChange = vi.fn();
+    const { container } = renderInputsEditor(makeInputs('Unset'), onChange);
+
+    // y is context + unset → placeholder mode
+    expect(screen.getByText(/using computed default/i)).toBeInTheDocument();
+    expect(container.querySelector('.context-var-editor')).toBeNull();
+
+    // click Override → editor appears
+    fireEvent.click(screen.getByRole('button', { name: /override/i }));
+    expect(screen.queryByText(/using computed default/i)).toBeNull();
+
+    // click × → back to placeholder
+    fireEvent.click(screen.getByRole('button', { name: '×' }));
+    expect(screen.getByText(/using computed default/i)).toBeInTheDocument();
+  });
+
+  it('typing an invalid value in an overridden context var keeps the editor visible', () => {
+    // y starts with a valid override (99) → override mode
+    const { container } = renderInputsEditor(makeInputs(99));
+
+    // sanity: no placeholder visible
+    expect(screen.queryByText(/using computed default/i)).toBeNull();
+
+    // type an invalid intermediate value
+    const input = container.querySelector(
+      '.context-var-editor input'
+    ) as HTMLInputElement;
+    expect(input).not.toBeNull();
+    fireEvent.change(input, { target: { value: '-' } });
+
+    // the editor must still be showing (not reverted to placeholder)
+    expect(screen.queryByText(/using computed default/i)).toBeNull();
+    expect(container.querySelector('.context-var-editor')).toBeInTheDocument();
+    // and the invalid indicator should be present
+    expect(
+      container.querySelector('.value-editor.invalid')
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/round_trip/context_vars.catala_en
+++ b/tests/round_trip/context_vars.catala_en
@@ -1,0 +1,14 @@
+> Module Context_vars
+
+```catala-metadata
+declaration scope C:
+  input x content integer
+  context y content integer
+  context output z content integer
+```
+
+```catala
+scope C:
+  definition y equals x + 10
+  definition z equals y * 2
+```

--- a/tests/round_trip/round_trip.sh
+++ b/tests/round_trip/round_trip.sh
@@ -5,6 +5,7 @@ cd "$(dirname "$0")"
 function cleanup(){
     rm -f rename_to_typecheck.catala_en
     rm -f to_typecheck.catala_en
+    rm -f context_vars_roundtrip.catala_en
     rm -rf _build
 }
 
@@ -21,3 +22,14 @@ clerk typecheck to_typecheck.catala_en || exit 1
 # generation + typecheck (regression test)
 catala testcase generate rename.catala_en --scope Example | catala testcase write --language en > rename_to_typecheck.catala_en
 clerk typecheck rename_to_typecheck.catala_en || exit 1
+
+# context variables: read/write round-trip must not emit definitions for unset context vars
+catala testcase read test_context_vars.catala_en | catala testcase write --language en > context_vars_roundtrip.catala_en
+# y override must be preserved, z must be absent (it was not in the source)
+grep -q "definition c\.y equals 99" context_vars_roundtrip.catala_en || { echo "FAIL: expected y override in round-trip output"; exit 1; }
+grep -q "definition c\.z" context_vars_roundtrip.catala_en && { echo "FAIL: unset context var z should not appear in round-trip output"; exit 1; }
+# the round-tripped file must typecheck
+clerk typecheck context_vars_roundtrip.catala_en || exit 1
+# run the original test and check the assertion passes (z = y*2 = 198)
+clerk run test_context_vars.catala_en
+catala testcase run --scope C_test test_context_vars.catala_en || exit 1

--- a/tests/round_trip/round_trip.sh
+++ b/tests/round_trip/round_trip.sh
@@ -31,5 +31,5 @@ grep -q "definition c\.z" context_vars_roundtrip.catala_en && { echo "FAIL: unse
 # the round-tripped file must typecheck
 clerk typecheck context_vars_roundtrip.catala_en || exit 1
 # run the original test and check the assertion passes (z = y*2 = 198)
-clerk run test_context_vars.catala_en
+clerk run test_context_vars.catala_en || exit 1
 catala testcase run --scope C_test test_context_vars.catala_en || exit 1

--- a/tests/round_trip/test_context_vars.catala_en
+++ b/tests/round_trip/test_context_vars.catala_en
@@ -1,0 +1,18 @@
+> Using Context_vars
+
+```catala-metadata
+#[test]
+#[testcase.testui]
+#[testcase.test_description = "Context variable round-trip: y is overridden, z uses its default (y*2=198)."]
+#[testcase.test_title = "Context vars test"]
+declaration scope C_test:
+  output c scope Context_vars.C
+
+```
+
+```catala
+scope C_test:
+  definition c.x equals 5
+  definition c.y equals 99
+  assertion (c.z = 198)
+```


### PR DESCRIPTION
This adds a specific display mark for context variables, plus the option to override them, or remove an existing override
[Kooha-2026-05-05-10-27-52.webm](https://github.com/user-attachments/assets/e3f21269-3c02-44ff-81d3-36e147d3ea33)


