### PR TITLE
Also scan sub-directories for clerk.toml

### DIFF
--- a/server/src/debug_evaluation.ml
+++ b/server/src/debug_evaluation.ml
@@ -302,7 +302,7 @@ let try_build_deps ~logger file =
 let run_debugger ?inputs rpc ~file ~scope logger : debugger_state Lwt.t =
   let* () = logger "Initializing Catala debugger.." in
   let build_dir, ((_, root) as config_and_root) =
-    match Utils.lookup_clerk_toml file with
+    match Utils.lookup_clerk_toml_in_parents file with
     | None -> "_build", (Clerk_config.default_config, ".")
     | Some (config, root) -> File.(root / "_build"), (config, root)
   in

--- a/server/src/document_processing.ml
+++ b/server/src/document_processing.ml
@@ -160,8 +160,19 @@ let surface_to_scopelang
       in
       check build_stdlib_path
       @@ fun () ->
-      Log.debug (fun m -> m "Stdlib not found - calling `clerk start`");
-      let _ = File.process_out "clerk" ["start"] in
+      let cmd, args =
+        ( "clerk",
+          [
+            "start";
+            "--build-dir";
+            File.(root_dir / clerk_config.global.build_dir);
+            "--target-dir";
+            File.(root_dir / clerk_config.global.target_dir);
+          ] )
+      in
+      Log.debug (fun m ->
+          m "Stdlib not found - calling `clerk %s`" (String.concat " " args));
+      let _ = File.process_out cmd args in
       check build_stdlib_path
       @@ fun () ->
       try

--- a/server/src/projects.ml
+++ b/server/src/projects.ml
@@ -452,36 +452,48 @@ let retrieve_project_files
   in
   project_files, known_modules
 
-let project_of_dir ~on_error dir =
-  match Utils.lookup_clerk_toml dir with
-  | None ->
-    Log.warn (fun m ->
-        m "no clerk config file found, assuming default configuration");
-    let project_dir = dir in
-    let project_files, known_modules =
-      retrieve_project_files ~on_error Clerk_config.default_config ~project_dir
-    in
-    let project_kind = No_clerk in
-    let project_graph = Project_graph.build_graph project_files in
-    { project_dir; project_kind; project_files; project_graph; known_modules }
-  | Some (clerk_config, clerk_root_dir) ->
-    Log.debug (fun m -> m "clerk file found in '%s' directory" clerk_root_dir);
-    let project_kind = Clerk { clerk_root_dir; clerk_config } in
-    let project_dir = clerk_root_dir in
-    let project_files, known_modules =
-      retrieve_project_files ~on_error clerk_config ~project_dir
-    in
-    let project_graph = Project_graph.build_graph project_files in
-    { project_dir; project_kind; project_files; project_graph; known_modules }
+let process_config ~on_error (clerk_config, clerk_root_dir) =
+  Log.debug (fun m -> m "clerk file found in '%s' directory" clerk_root_dir);
+  let project_kind = Clerk { clerk_root_dir; clerk_config } in
+  let project_dir = clerk_root_dir in
+  let project_files, known_modules =
+    retrieve_project_files ~on_error clerk_config ~project_dir
+  in
+  let project_graph = Project_graph.build_graph project_files in
+  { project_dir; project_kind; project_files; project_graph; known_modules }
 
-let project_of_workspace_folder ~on_error workspace_folder =
+let default_config_from_dir ~on_error dir =
+  Log.warn (fun m ->
+      m "no clerk config file found, assuming default configuration");
+  let project_dir = dir in
+  let project_files, known_modules =
+    retrieve_project_files ~on_error Clerk_config.default_config ~project_dir
+  in
+  let project_kind = No_clerk in
+  let project_graph = Project_graph.build_graph project_files in
+  { project_dir; project_kind; project_files; project_graph; known_modules }
+
+let project_of_dir ~on_error dir =
+  match Utils.lookup_clerk_toml_in_parents dir with
+  | Some conf -> process_config ~on_error conf
+  | None -> default_config_from_dir ~on_error dir
+
+let projects_of_dir ~on_error dir =
+  match Utils.lookup_clerk_tomls_in_sub_directories ~on_error dir with
+  | None -> [project_of_dir ~on_error dir]
+  | Some configs -> List.map (process_config ~on_error) configs
+
+let projects_of_workspace_folder ~on_error workspace_folder =
   (* Normalize path *)
   let project_dir =
     Uri.pct_decode
       (Linol_lwt.DocumentUri.to_path
          workspace_folder.Linol_lwt.WorkspaceFolder.uri)
   in
-  project_of_dir ~on_error project_dir
+  (* TODO? Should we allow sub-clerk projects? I.e., should a clerk.toml in a
+     sub-directory have priority over a parent clerk.toml and disjointing its
+     project files from it? *)
+  projects_of_dir ~on_error project_dir
 
 let init ~on_error (params : Linol_lwt.InitializeParams.t) : projects =
   let ( let*? ) (x, err_msg) f =
@@ -504,10 +516,15 @@ let init ~on_error (params : Linol_lwt.InitializeParams.t) : projects =
   let*? workspace_folders = workspace_folders, no_workspace_folder_provided in
   List.fold_left
     (fun projects workspace_folder ->
-      let project = project_of_workspace_folder ~on_error workspace_folder in
-      Log.app (fun m -> m "project %s loaded" project.project_dir);
-      Log.debug (fun m -> m "@[<v 2>Projects:@ %a@]" format_project project);
-      Projects.add project projects)
+      let new_projects =
+        projects_of_workspace_folder ~on_error workspace_folder
+      in
+      List.fold_left
+        (fun projects project ->
+          Log.app (fun m -> m "project %s loaded" project.project_dir);
+          Log.debug (fun m -> m "@[<v 2>project:@ %a@]" format_project project);
+          Projects.add project projects)
+        projects new_projects)
     Projects.empty workspace_folders
 
 let find_file_in_project doc_id (project : project) =

--- a/server/src/utils.ml
+++ b/server/src/utils.ml
@@ -167,72 +167,92 @@ let lookup_catala_enable_project_scan ~(notify_back : Jsonrpc2.notify_back) :
   in
   r
 
-let lookup_clerk_toml (path : string) =
-  let open Catala_utils in
-  let process_clerk_toml clerk_toml_dir =
-    Log.debug (fun m ->
-        m "found config file at: '%s'"
-          (Filename.concat clerk_toml_dir "clerk.toml"));
-    try
-      let config = Clerk_config.read File.(clerk_toml_dir / "clerk.toml") in
-      let include_dirs =
-        List.map (File.( / ) clerk_toml_dir) config.global.include_dirs
-      in
-      let config =
-        { config with global = { config.global with include_dirs } }
-      in
-      Some (config, clerk_toml_dir)
-    with Message.CompilerError c ->
-      Log.err (fun m ->
-          let pp fmt = Message.Content.emit ~ppf:fmt c Error in
-          m "error while parsing config file: %t" pp);
-      None
-  in
+let process_clerk_toml clerk_toml_dir =
+  try
+    let config = Clerk_config.read File.(clerk_toml_dir / "clerk.toml") in
+    let include_dirs =
+      List.map (File.( / ) clerk_toml_dir) config.global.include_dirs
+    in
+    let config = { config with global = { config.global with include_dirs } } in
+    Some (config, clerk_toml_dir)
+  with Message.CompilerError c ->
+    Log.err (fun m ->
+        let pp fmt = Message.Content.emit ~ppf:fmt c Error in
+        m "error while parsing config file: %t" pp);
+    None
+
+let lookup_clerk_toml_in_parents (path : string) :
+    (Clerk_config.config_file * string) option =
   let from_dir =
     if Sys.is_directory path then path else Filename.dirname path
   in
-  try
-    begin match
-      File.find_in_parents ~cwd:from_dir (fun dir ->
-          File.(exists (dir / "clerk.toml")))
-    with
-    | None -> (
-      Log.debug (fun m ->
-          m
-            "no 'clerk.toml' config file found in parents: scanning \
-             sub-directories");
-      let is_clerk_toml f = String.equal (File.basename f) "clerk.toml" in
-      let clerk_tomls =
-        File.scan_tree
-          (fun f ->
-            Log.debug (fun m -> m "%s" f);
-            if is_clerk_toml f then Some f else None)
-          from_dir
-        |> List.of_seq
-      in
-      match
-        List.find_map
-          (fun (dir, _, items) ->
-            if List.exists is_clerk_toml items then Some dir else None)
-          clerk_tomls
-      with
-      | Some dir ->
-        Log.debug (fun m ->
-            m
-              "found a 'clerk.toml' config file in '%s' sub-directory: using \
-               this one"
-              dir);
-        Log.warn (fun m ->
-            m
-              "it is recommended to declare the 'clerk.toml' configuration \
-               file at the workspace's root");
-        process_clerk_toml dir
-      | None -> None)
-    | Some (dir, _) -> process_clerk_toml dir
-    end
-  with _ ->
-    Log.err (fun m -> m "failed to lookup config file");
+  let open Catala_utils in
+  match
+    File.find_in_parents ~cwd:from_dir (fun dir ->
+        File.(exists (dir / "clerk.toml")))
+  with
+  | None ->
+    Log.debug (fun m -> m "no 'clerk.toml' config file found");
     None
+  | Some (dir, _) -> process_clerk_toml dir
+
+let lookup_clerk_tomls_in_sub_directories ~on_error (path : string) :
+    (Clerk_config.config_file * string) list option =
+  let open Catala_utils in
+  let from_dir =
+    if Sys.is_directory path then path else Filename.dirname path
+  in
+  let is_clerk_toml f = String.equal (File.basename f) "clerk.toml" in
+  let clerk_tomls =
+    File.scan_tree (fun f -> if is_clerk_toml f then Some f else None) from_dir
+    |> List.of_seq
+  in
+  let all_clerk_tomls =
+    List.filter_map
+      (fun (dir, _, items) ->
+        if List.exists is_clerk_toml items then Some dir else None)
+      clerk_tomls
+    |> List.sort File.compare
+  in
+  let rec remove_suffixes (acc, ignored) pred = function
+    | [] -> acc, ignored
+    | h :: t ->
+      if String.starts_with ~prefix:pred h then
+        remove_suffixes (acc, (h, pred) :: ignored) pred t
+      else remove_suffixes (h :: acc, ignored) h t
+  in
+  match all_clerk_tomls with
+  | [] -> None
+  | h :: t -> (
+    let clerk_tomls_dirs, ignored_dirs = remove_suffixes ([h], []) h t in
+    if ignored_dirs <> [] then (
+      Log.warn (fun m ->
+          m "ignoring lower priority config files: %s."
+            (String.concat ", "
+               (List.map (fun (d, _) -> File.(d / "clerk.toml")) ignored_dirs)));
+      List.iter
+        (fun (d, parent) ->
+          let f = Doc_id.of_file File.(d / "clerk.toml") in
+          let range =
+            Range.create
+              ~start:{ line = 0; character = 0 }
+              ~end_:{ line = 10000; character = 0 }
+          in
+          let diag =
+            Linol_lwt.Diagnostic.create ~range ~severity:Warning
+              ~source:"catala-lsp"
+              ~message:
+                (`String
+                   (Format.sprintf
+                      "Ignored 'clerk.toml' configuration file, a parent \
+                       'clerk.toml' is present at %s/clerk.toml "
+                      parent))
+              ()
+          in
+          on_error (f, range, diag))
+        ignored_dirs);
+    List.filter_map process_clerk_toml clerk_tomls_dirs
+    |> function [] -> None | l -> Some l)
 
 let list_scopes ~tests_only file : Shared_ast.ScopeName.t list =
   let open Shared_ast in

--- a/server/src/utils.ml
+++ b/server/src/utils.ml
@@ -168,35 +168,67 @@ let lookup_catala_enable_project_scan ~(notify_back : Jsonrpc2.notify_back) :
   r
 
 let lookup_clerk_toml (path : string) =
+  let open Catala_utils in
+  let process_clerk_toml clerk_toml_dir =
+    Log.debug (fun m ->
+        m "found config file at: '%s'"
+          (Filename.concat clerk_toml_dir "clerk.toml"));
+    try
+      let config = Clerk_config.read File.(clerk_toml_dir / "clerk.toml") in
+      let include_dirs =
+        List.map (File.( / ) clerk_toml_dir) config.global.include_dirs
+      in
+      let config =
+        { config with global = { config.global with include_dirs } }
+      in
+      Some (config, clerk_toml_dir)
+    with Message.CompilerError c ->
+      Log.err (fun m ->
+          let pp fmt = Message.Content.emit ~ppf:fmt c Error in
+          m "error while parsing config file: %t" pp);
+      None
+  in
   let from_dir =
     if Sys.is_directory path then path else Filename.dirname path
   in
-  let open Catala_utils in
   try
     begin match
       File.find_in_parents ~cwd:from_dir (fun dir ->
           File.(exists (dir / "clerk.toml")))
     with
-    | None ->
-      Log.debug (fun m -> m "no 'clerk.toml' config file found");
-      None
-    | Some (dir, _) -> (
+    | None -> (
       Log.debug (fun m ->
-          m "found config file at: '%s'" (Filename.concat dir "clerk.toml"));
-      try
-        let config = Clerk_config.read File.(dir / "clerk.toml") in
-        let include_dirs =
-          List.map (File.( / ) dir) config.global.include_dirs
-        in
-        let config =
-          { config with global = { config.global with include_dirs } }
-        in
-        Some (config, dir)
-      with Message.CompilerError c ->
-        Log.err (fun m ->
-            let pp fmt = Message.Content.emit ~ppf:fmt c Error in
-            m "error while parsing config file: %t" pp);
-        None)
+          m
+            "no 'clerk.toml' config file found in parents: scanning \
+             sub-directories");
+      let is_clerk_toml f = String.equal (File.basename f) "clerk.toml" in
+      let clerk_tomls =
+        File.scan_tree
+          (fun f ->
+            Log.debug (fun m -> m "%s" f);
+            if is_clerk_toml f then Some f else None)
+          from_dir
+        |> List.of_seq
+      in
+      match
+        List.find_map
+          (fun (dir, _, items) ->
+            if List.exists is_clerk_toml items then Some dir else None)
+          clerk_tomls
+      with
+      | Some dir ->
+        Log.debug (fun m ->
+            m
+              "found a 'clerk.toml' config file in '%s' sub-directory: using \
+               this one"
+              dir);
+        Log.warn (fun m ->
+            m
+              "it is recommended to declare the 'clerk.toml' configuration \
+               file at the workspace's root");
+        process_clerk_toml dir
+      | None -> None)
+    | Some (dir, _) -> process_clerk_toml dir
     end
   with _ ->
     Log.err (fun m -> m "failed to lookup config file");


### PR DESCRIPTION
This PR allows clerk.toml to be present in a workspace's sub-directory. If multiple are present, we choose the first one based on the `File.scan_tree` lexicographical order. The build/target directories are also generated in this sub-directory.