### PR TITLE
Improve performance of position map computation

### DIFF
--- a/server/src/debug_evaluation.ml
+++ b/server/src/debug_evaluation.ml
@@ -54,7 +54,7 @@ type debugger_state = {
   file : Doc_id.t;
   scope : ScopeName.t;
   program : typed Dcalc.Ast.program;
-  pmap : PMap.t;
+  pmap : PMap.pmap;
   all_steps : step array;
   mutable index : int;
   final_index : int;
@@ -272,20 +272,18 @@ let load_program options ((clerk_config : Clerk_config.t), root_dir) file scope
     (* Do not optimize, we lose some relevant locations *)
   in
   let scope = find_scope prg scope in
-  let pmap =
+  let acc =
     let e = Expr.unbox (Program.to_expr prg scope) |> Interpreter.addcustom in
     let rec process e acc =
       let acc =
-        match Mark.remove e with
-        (* | ELit _ -> acc *)
-        | _be ->
-          let pos = get_pos e in
-          PMap.add pos e acc
+        let pos = get_pos e in
+        PMap.add pos e acc
       in
       Expr.shallow_fold process e acc
     in
-    process e PMap.empty
+    process e PMap.empty_acc
   in
+  let pmap = PMap.finalize acc in
   prg, scope, pmap
 
 let try_build_deps ~logger file =
@@ -365,7 +363,8 @@ let possible_breakpoints runner doc_id line : Breakpoint_location.t list =
   in
   match PMap.lookup_on_line doc_id line runner.pmap with
   | None -> []
-  | Some l ->
+  | Some elts ->
+    let l = PMap.DS.elements elts in
     Log.debug (fun m ->
         m "possible breakpoints for line %d on lines: [%a]" line
           Format.(
@@ -414,7 +413,7 @@ let continue_back_until_breakpoint state : [ `Start | `B of step ] =
   in
   loop ()
 
-let find_breakpoint (pos_map : PMap.t) doc_id (bp : Source_breakpoint.t) :
+let find_breakpoint (pos_map : PMap.pmap) doc_id (bp : Source_breakpoint.t) :
     (Pos.t * Breakpoint.t) option =
   match bp.column with
   | None -> begin

--- a/server/src/doc_queries.ml
+++ b/server/src/doc_queries.ml
@@ -33,10 +33,10 @@ let all_symbols_as_warning (doc_id : Doc_id.t) processing_result =
   let diags : (Doc_id.doc_id * Diagnostic.t list) list =
     match processing_result with
     | Skipped | Faulty _ -> []
-    | Partial (_, { jump_table = (lazy { variables; lookup_table }); _ })
-    | Valid { jump_table = (lazy { variables; lookup_table }); _ } ->
+    | Partial (_, { jump_table = (lazy { pos_map; lookup_table }); _ })
+    | Valid { jump_table = (lazy { pos_map; lookup_table }); _ } ->
       (* Displays the full position map in logs *)
-      (* Log.info (fun m -> m "%a@." Jump_table.PMap.pp variables); *)
+      (* Log.info (fun m -> m "%a@." Jump_table.PMap.format pos_map); *)
       (* Generates warning diagnostic for each symbol *)
       [
         ( doc_id,
@@ -73,7 +73,7 @@ let all_symbols_as_warning (doc_id : Doc_id.t) processing_result =
                     r
                 in
                 Diagnostic.diag_r Warning (range_of_pos r) (`String msg) :: acc)
-              variables [] );
+              pos_map [] );
         ]
   in
   let m : diagnostic Range.Map.t Doc_id.Map.t =
@@ -189,7 +189,7 @@ let get_hover_type ?(markdown = false) f p =
     let md = Type_printing.typ_to_markdown prg f.locale kind in
     let definition_tree_link =
       let open Jump_table in
-      let*? l = PMap.lookup p jt.variables in
+      let*? l = PMap.lookup p jt.pos_map in
       let id =
         PMap.DS.elements l
         |> List.find_map (function
@@ -300,7 +300,7 @@ let lookup_document_symbols file =
           | None -> acc
           | Some v -> v :: acc)
         vl acc)
-    jt.variables []
+    jt.pos_map []
 
 let lookup_lenses file =
   let*? { jump_table = (lazy jt); _ } = file.last_valid_result in
@@ -369,7 +369,7 @@ let lookup_lenses file =
               else mk_input_lens scope_decl_name (range_of_pos p) @ acc
             | _ -> acc)
           vl acc)
-      jt.variables []
+      jt.pos_map []
   in
   Some scope_lenses
 
@@ -381,7 +381,7 @@ let exceptions_at (file : document_state) (p : Linol_lwt.Position.t) :
   let doc_id = file.document_id in
   let p = Utils.(lsp_range p p |> pos_of_range (file.document_id :> File.t)) in
   let open Jump_table in
-  let*? l : PMap.DS.t = PMap.lookup p jt.variables in
+  let*? l : PMap.DS.t = PMap.lookup p jt.pos_map in
   let x =
     PMap.DS.elements l
     |> List.filter_map (function

--- a/server/src/jump_table.ml
+++ b/server/src/jump_table.ml
@@ -144,8 +144,7 @@ type traversal_ctxt = {
   scope_lookup : sjump ScopeName.Map.t;
 }
 
-type variables = PMap.pmap
-type t = { variables : variables; lookup_table : lookup_entry LTable.t }
+type t = { pos_map : PMap.pmap; lookup_table : lookup_entry LTable.t }
 
 let pp_table ppf { declaration; definitions; usages; types } =
   let open Format in
@@ -301,7 +300,7 @@ let populate_scopecall (tctx : traversal_ctxt) pos scope args acc f =
     args acc
 
 let rec traverse_typ (tctx : traversal_ctxt) ((typ, pos) : naked_typ * Pos.t) m
-    : PMap.pmap =
+    : PMap.acc =
   match typ with
   | TStruct struct_name -> begin
     StructName.Map.find_opt struct_name tctx.scope_structs
@@ -446,7 +445,7 @@ let traverse_expr (tctx : traversal_ctxt) (e : (scopelang, typed) gexpr) m =
   in
   f Bindlib.empty_ctxt e m
 
-let traverse_scope_def tctx (rule : typed rule) m : PMap.pmap =
+let traverse_scope_def tctx (rule : typed rule) m : PMap.acc =
   match rule with
   | ScopeVarDefinition { var; typ; io = _; e } ->
     let var, pos_l = var in
@@ -463,7 +462,7 @@ let traverse_scope_def tctx (rule : typed rule) m : PMap.pmap =
     traverse_expr tctx e m
   | Assertion e -> traverse_expr tctx e.e m
 
-let traverse_scope_sig tctx (scope : _ scope_decl) m : PMap.pmap =
+let traverse_scope_sig tctx (scope : _ scope_decl) m : PMap.acc =
   ScopeVar.Map.fold
     (fun scope_var var_ty m ->
       (* FIXME: subscope type definition is buggy *)
@@ -483,7 +482,7 @@ let traverse_scope_sig tctx (scope : _ scope_decl) m : PMap.pmap =
       PMap.add pos var m)
     scope.scope_sig m
 
-let traverse_scope tctx (scope : typed scope_decl) m : PMap.pmap =
+let traverse_scope tctx (scope : typed scope_decl) m : PMap.acc =
   let m = traverse_scope_sig tctx scope m in
   List.fold_right (traverse_scope_def tctx) scope.scope_decl_rules m
 
@@ -491,7 +490,7 @@ let traverse_topdef
     tctx
     (topdef : TopdefName.t)
     ((e, typ, _vis, _meta) : typed expr * typ * visibility * bool)
-    m : PMap.pmap =
+    m : PMap.acc =
   let name = TopdefName.to_string topdef in
   let topdef_pos = snd (TopdefName.get_info topdef) in
   let hash = Hashtbl.hash (TopdefName.get_info topdef) in
@@ -500,7 +499,7 @@ let traverse_topdef
   let m = traverse_typ tctx typ m in
   traverse_expr tctx e m
 
-let traverse_ctx (tctx : traversal_ctxt) m : PMap.pmap =
+let traverse_ctx (tctx : traversal_ctxt) m : PMap.acc =
   let m =
     StructName.Map.fold
       (fun struct_name (fields, _vis) m ->
@@ -553,7 +552,7 @@ let traverse
     (ctx : Desugared.Name_resolution.context)
     (module_lookup : ModuleName.t -> mjump)
     (prog : _ program)
-    (m : PMap.pmap) =
+    (m : PMap.acc) =
   let (all_scopes : typed scope_decl list) =
     ScopeName.Map.values prog.program_scopes |> List.map Mark.remove
   in
@@ -613,7 +612,7 @@ let traverse
 let add_scope_definitions
     (tctx : traversal_ctxt)
     (surface : Surface.Ast.program)
-    (variables : PMap.t) =
+    (pmap : PMap.acc) =
   let rec process vars_acc = function
     | Surface.Ast.CodeBlock (cb, _, _) ->
       List.fold_left
@@ -637,14 +636,14 @@ let add_scope_definitions
     | LawHeading (_, ls) -> List.fold_left process vars_acc ls
     | LawInclude _ | ModuleDef _ | ModuleUse _ | LawText _ -> vars_acc
   in
-  List.fold_left process variables surface.program_items
+  List.fold_left process pmap surface.program_items
 
 let populate_modules
     input_src
     (modules_contents : Surface.Ast.module_content ModuleName.Map.t)
     (prog : typed program)
     (surface : Surface.Ast.program)
-    (acc : PMap.t) : PMap.t * (ModuleName.t -> mjump) =
+    (acc : PMap.acc) : PMap.acc * (ModuleName.t -> mjump) =
   let module C = Map.Make (String) in
   let convert_map =
     ModuleName.Map.fold
@@ -725,11 +724,12 @@ let populate
     (modules_contents : Surface.Ast.module_content ModuleName.Map.t)
     (surface : Surface.Ast.program)
     (prog : typed program) : t =
-  let variables, mod_lookup =
-    populate_modules input_src modules_contents prog surface PMap.empty
+  let acc, mod_lookup =
+    populate_modules input_src modules_contents prog surface PMap.empty_acc
   in
-  let variables, tctx = traverse ctx mod_lookup prog variables in
-  let variables = add_scope_definitions tctx surface variables in
+  let acc, tctx = traverse ctx mod_lookup prog acc in
+  let acc = add_scope_definitions tctx surface acc in
+  let pos_map = PMap.finalize acc in
   let add f = function None -> Some (f empty_lookup) | Some v -> Some (f v) in
   let add_def p =
     add (fun v ->
@@ -784,9 +784,9 @@ let populate
             | Some (add, hash) -> LTable.update hash add tbl
             | _ -> tbl)
           data tbl)
-      variables LTable.empty
+      pos_map LTable.empty
   in
-  { variables; lookup_table }
+  { pos_map; lookup_table }
 
 let lookup (tables : t) (p : Pos.t) : lookup_entry list =
   let proj = function
@@ -801,7 +801,7 @@ let lookup (tables : t) (p : Pos.t) : lookup_entry list =
       LTable.find_opt hash tables.lookup_table
     | Literal _ -> None
   in
-  PMap.lookup p tables.variables
+  PMap.lookup p tables.pos_map
   |> function None -> [] | Some s -> List.filter_map proj (PMap.DS.elements s)
 
 type type_lookup =
@@ -842,7 +842,7 @@ let lookup_type (tables : t) (p : Pos.t) :
     | Module_def { mcontent; alias; _ } ->
       Module (mcontent, alias)
   in
-  PMap.lookup_with_range p tables.variables
+  PMap.lookup_with_range p tables.pos_map
   |> function
   | None -> None
   | Some (r, d) ->

--- a/server/src/main_dap.ml
+++ b/server/src/main_dap.ml
@@ -694,7 +694,7 @@ let set_handlers rpc =
     (fun () ->
       use_state
       @@ fun s ->
-      let doc_ids = Doc_id.Map.keys s.pmap in
+      let doc_ids = DE.PMap.files s.pmap in
       let sources : Source.t list = List.map doc_id_to_source doc_ids in
       Lwt.return { Loaded_sources_command.Result.sources })
 

--- a/server/src/position_map.ml
+++ b/server/src/position_map.ml
@@ -23,38 +23,40 @@ module type Data = sig
   val format : Format.formatter -> t -> unit
 end
 
-module Make_trie (D : Data) = struct
+module MakeTree (D : Data) = struct
   module DS = Set.Make (D)
 
   type itv = (int (* line *) * int (* col *)) * (int (* line *) * int (* col *))
 
-  type node = Node of { itv : itv; data : DS.t; children : trie }
-  and trie = node list
+  type node = Node of { itv : itv; data : DS.t; children : tree }
+  and tree = node list
 
-  type t = trie
+  type t = tree
 
-  let pp_itv ppf ((li, i), (lj, j)) =
+  let format_itv ppf ((li, i), (lj, j)) =
     Format.fprintf ppf "(%d:%d)⟷(%d:%d)" li i lj j
 
   let itv_to_range ((li, i), (lj, j)) =
     let pos = Catala_utils.Pos.from_info "" li i lj j in
     Utils.range_of_pos pos
 
-  let rec pp_node ppf (Node { itv; data; children }) =
+  let rec format_node ppf (Node { itv; data; children }) =
     let open Format in
     match children with
     | [] ->
-      fprintf ppf "@[<h>%a: [ @[<h>%a@] ]@]" pp_itv itv
+      fprintf ppf "@[<h>%a: [ @[<h>%a@] ]@]" format_itv itv
         (pp_print_list ~pp_sep:(fun fmt () -> fprintf fmt " ; ") D.format)
         (DS.elements data)
     | _ ->
-      fprintf ppf "@[<v 2>%a: [ @[<h>%a@] ]@ %a@]" pp_itv itv
+      fprintf ppf "@[<v 2>%a: [ @[<h>%a@] ]@ %a@]" format_itv itv
         (pp_print_list ~pp_sep:pp_print_space D.format)
-        (DS.elements data) pp_trie children
+        (DS.elements data) format_tree children
 
-  and pp_trie ppf tries =
+  and format_tree ppf trees =
     let open Format in
-    fprintf ppf "@[<v>%a@]" (pp_print_list ~pp_sep:pp_print_cut pp_node) tries
+    fprintf ppf "@[<v>%a@]"
+      (pp_print_list ~pp_sep:pp_print_cut format_node)
+      trees
 
   let is_in ((li, i), (lj, j)) (ln, n) =
     (ln > li && ln < lj)
@@ -65,16 +67,16 @@ module Make_trie (D : Data) = struct
   let is_in_line ((li, _), (lj, _)) ln = ln >= li && ln <= lj
   let is_included itv (left, right) = is_in itv left && is_in itv right
 
-  let rec lookup i trie =
-    List.find_opt (fun (Node { itv; _ }) -> is_in itv i) trie
+  let rec lookup i tree =
+    List.find_opt (fun (Node { itv; _ }) -> is_in itv i) tree
     |> function
     | None -> None
     | Some (Node { children = []; data; _ }) -> Some data
     | Some (Node { children; data; _ }) -> (
       match lookup i children with None -> Some data | Some v -> Some v)
 
-  let rec lookup_with_range i trie =
-    List.find_opt (fun (Node { itv; _ }) -> is_in itv i) trie
+  let rec lookup_with_range i tree =
+    List.find_opt (fun (Node { itv; _ }) -> is_in itv i) tree
     |> function
     | None -> None
     | Some (Node { itv; children = []; data }) -> Some (itv_to_range itv, data)
@@ -83,25 +85,25 @@ module Make_trie (D : Data) = struct
       | None -> Some (itv_to_range itv, data)
       | Some v -> Some v)
 
-  let all_nodes trie =
+  let all_nodes tree =
     let rev_nodes = ref [] in
     let rec loop (Node { children; _ } as x) =
       rev_nodes := x :: !rev_nodes;
       List.iter loop children
     in
-    List.iter loop trie;
+    List.iter loop tree;
     List.rev !rev_nodes
 
-  let lookup_on_line l trie =
-    List.find_all (fun (Node { itv; _ }) -> is_in_line itv l) trie
+  let lookup_on_line l tree =
+    List.find_all (fun (Node { itv; _ }) -> is_in_line itv l) tree
     |> all_nodes
     |> List.filter (fun (Node { itv = (li, _), (lj, _); _ }) ->
         not (li <> l || lj <> l))
     |> List.map (fun (Node { data; _ }) -> data)
     |> function [] -> None | l -> Some l
 
-  let lookup_best_on_line (l : int) trie : DS.t option =
-    match List.find_all (fun (Node { itv; _ }) -> is_in_line itv l) trie with
+  let lookup_best_on_line (l : int) tree : DS.t option =
+    match List.find_all (fun (Node { itv; _ }) -> is_in_line itv l) tree with
     | [] -> None
     | candidates -> (
       let compare_candidate
@@ -137,13 +139,7 @@ module Make_trie (D : Data) = struct
         ( ((li', i'), (li, i - 1)) (* disjoint part *),
           ((li, i), (lj', j')) (* included part *) ))
 
-  let rec gather_children (Node { children; _ }) =
-    let fresh_children =
-      List.map (fun (Node node) -> Node { node with children = [] }) children
-    in
-    fresh_children @ List.concat_map gather_children children
-
-  let rec insert_all itv (data : DS.t) trie =
+  let rec insert_all itv (data : DS.t) tree =
     let rec find_included_nodes acc = function
       | [] -> List.rev acc, `Disjoint []
       | (Node n as h) :: t as l -> (
@@ -156,7 +152,7 @@ module Make_trie (D : Data) = struct
         | `Left_inclusion (included_itv, _disjoint_part) ->
           acc, `Joint (included_itv, l))
     in
-    let rec loop acc itv : trie -> trie = function
+    let rec loop acc itv : tree -> tree = function
       | [] -> Node { itv; data; children = [] } :: acc |> List.rev
       | (Node ({ itv = itv_p; children; _ } as node_r) as node) :: t as l -> (
         match compare_itv itv_p itv with
@@ -201,32 +197,25 @@ module Make_trie (D : Data) = struct
             (Node { node_r with children = new_children } :: acc)
             t)
     in
-    loop [] itv trie
+    loop [] itv tree
 end
 
 open Catala_utils
 
 module Make (D : Data) = struct
-  module Trie = Make_trie (D)
-  module DS = Trie.DS
+  module Tree = MakeTree (D)
+  module DS = Tree.DS
 
-  type pmap = Trie.t Doc_id.Map.t
-  type t = pmap
+  type pmap = Tree.t Doc_id.Map.t
+  type acc = (Pos.t * D.t) list
 
-  let pp ppf pmap =
+  let empty_acc = []
+
+  let format ppf pmap =
     let open Format in
     fprintf ppf "@[<v 2>variables:@ %a@]"
-      (Doc_id.Map.format ~pp_sep:pp_print_cut Trie.pp_trie)
+      (Doc_id.Map.format ~pp_sep:pp_print_cut Tree.format_tree)
       pmap
-
-  let ( -- ) i j = List.init (j - i + 1) (fun x -> i + x)
-
-  let merge_tries _i trie trie' : Trie.t option =
-    match trie, trie' with
-    | None, None -> None
-    | None, Some (itv, data) -> Some [Node { itv; data; children = [] }]
-    | Some trie, None -> Some trie
-    | Some trie, Some (itv, data) -> Some (Trie.insert_all itv data trie)
 
   let pos_to_itv pos =
     let li = Pos.get_start_line pos in
@@ -235,9 +224,9 @@ module Make (D : Data) = struct
     let j = Pos.get_end_column pos in
     (li, i), (lj, j)
 
-  let pp_raw ppf (p, d) =
+  let format_entry ppf (p, d) =
     let open Format in
-    fprintf ppf "@[<h>%a: %a@]" Trie.pp_itv (pos_to_itv p) D.format d
+    fprintf ppf "@[<h>%a: %a@]" Tree.format_itv (pos_to_itv p) D.format d
 
   let add_all pos data variables =
     if pos = Pos.void then variables
@@ -246,45 +235,56 @@ module Make (D : Data) = struct
       let data = DS.of_list data in
       Doc_id.Map.update (Doc_id.of_catala_pos pos)
         (function
-          | None -> Some [Trie.Node { itv; data; children = [] }]
-          | Some trie -> Some (Trie.insert_all itv data trie))
+          | None -> Some [Tree.Node { itv; data; children = [] }]
+          | Some tree -> Some (Tree.insert_all itv data tree))
         variables
 
   let add pos data variables = add_all pos [data] variables
 
-  let lookup pos pmap =
+  let finalize acc =
+    List.fold_left (fun m (pos, d) -> add pos d m) Doc_id.Map.empty acc
+
+  let add pos data acc = (pos, data) :: acc
+
+  let add_all pos datas acc =
+    List.fold_left (fun acc d -> (pos, d) :: acc) acc datas
+
+  let lookup pos (pmap : pmap) =
     let ( let* ) = Option.bind in
     (* we assume that pos's start/end lines, start/end column are equal *)
-    let* trie = Doc_id.Map.find_opt (Doc_id.of_catala_pos pos) pmap in
-    Trie.lookup (Pos.get_start_line pos, Pos.get_start_column pos) trie
+    let* tree = Doc_id.Map.find_opt (Doc_id.of_catala_pos pos) pmap in
+    Tree.lookup (Pos.get_start_line pos, Pos.get_start_column pos) tree
 
   let lookup_with_range pos pmap =
     let ( let* ) = Option.bind in
     (* we assume that pos's start/end lines, start/end column are equal *)
-    let* trie = Doc_id.Map.find_opt (Doc_id.of_catala_pos pos) pmap in
-    Trie.lookup_with_range
+    let* tree = Doc_id.Map.find_opt (Doc_id.of_catala_pos pos) pmap in
+    Tree.lookup_with_range
       (Pos.get_start_line pos, Pos.get_start_column pos)
-      trie
+      tree
 
   let lookup_best_on_line doc_id l pmap =
     let ( let* ) = Option.bind in
     (* we assume that pos's start/end lines, start/end column are equal *)
-    let* trie = Doc_id.Map.find_opt doc_id pmap in
-    Trie.lookup_best_on_line l trie |> Option.map DS.choose
+    let* tree = Doc_id.Map.find_opt doc_id pmap in
+    Tree.lookup_best_on_line l tree |> Option.map DS.choose
 
-  let lookup_on_line doc_id l pmap =
+  let lookup_on_line doc_id l (pmap : pmap) =
     let ( let* ) = Option.bind in
     (* we assume that pos's start/end lines, start/end column are equal *)
-    let* trie = Doc_id.Map.find_opt doc_id pmap in
-    Trie.lookup_on_line l trie |> Option.map (List.concat_map DS.elements)
+    let* tree = Doc_id.Map.find_opt doc_id pmap in
+    Tree.lookup_on_line l tree
+    |> Option.map (fun ld -> List.fold_left DS.union DS.empty ld)
+
+  let files pmap = Doc_id.Map.keys pmap
 
   let fold f pmap acc =
-    let rec fold (doc_id : Doc_id.t) trie acc =
+    let rec fold (doc_id : Doc_id.t) tree acc =
       List.fold_left
-        (fun acc (Trie.Node { itv = (li, i), (lj, j); children; data }) ->
+        (fun acc (Tree.Node { itv = (li, i), (lj, j); children; data }) ->
           let acc = f (Pos.from_info (doc_id :> File.t) li i lj j) data acc in
           fold doc_id children acc)
-        acc trie
+        acc tree
     in
     Doc_id.Map.fold fold pmap acc
 
@@ -295,5 +295,4 @@ module Make (D : Data) = struct
     | Some pmap -> fold f (Doc_id.Map.singleton file pmap) acc
 
   let iter f pmap = fold (fun k v () -> f k v) pmap ()
-  let empty = Doc_id.Map.empty
 end

--- a/server/src/position_map.mli
+++ b/server/src/position_map.mli
@@ -1,0 +1,71 @@
+(* This file is part of the Catala compiler, a specification language for tax
+   and social benefits computation rules. Copyright (C) 2026 Inria, contributor:
+   Vincent Botbol <vincent.botbol@inria.fr>
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License. *)
+
+open Server_types
+open Catala_utils
+
+module type Data = sig
+  type t
+
+  val compare : t -> t -> int
+  val format : Format.formatter -> t -> unit
+end
+
+module MakeTree (D : Data) : sig
+  module DS : Set.S with type elt = D.t
+
+  type itv = (int * int) * (int * int)
+
+  type node = Node of { itv : itv; data : DS.t; children : tree }
+  and tree = node list
+
+  type t = tree
+end
+
+module Make (D : Data) : sig
+  module DS : Set.S with type elt = D.t
+  module Tree : module type of MakeTree (D)
+
+  type acc
+  type pmap = Tree.t Doc_id.Map.t (* Exposed for testing *)
+
+  val format : Format.formatter -> pmap -> unit
+  val format_entry : Format.formatter -> Pos.t * D.t -> unit
+
+  (** Construction *)
+
+  val empty_acc : acc
+  val add : Pos.t -> D.t -> acc -> acc
+  val add_all : Pos.t -> D.t list -> acc -> acc
+  val finalize : acc -> pmap
+
+  (** Queries *)
+
+  val lookup : Pos.t -> pmap -> DS.t option
+  val lookup_with_range : Pos.t -> pmap -> (Range.t * DS.t) option
+  val lookup_best_on_line : Doc_id.t -> int -> pmap -> D.t option
+  val lookup_on_line : Doc_id.t -> int -> pmap -> DS.t option
+  val files : pmap -> Doc_id.t list
+
+  (** Iterators *)
+
+  val fold : (Pos.t -> DS.t -> 'acc -> 'acc) -> pmap -> 'acc -> 'acc
+
+  val fold_on_file :
+    Doc_id.doc_id -> (Pos.t -> DS.t -> 'acc -> 'acc) -> pmap -> 'acc -> 'acc
+
+  val iter : (Pos.t -> DS.t -> unit) -> pmap -> unit
+end

--- a/server/test/test.ml
+++ b/server/test/test.ml
@@ -55,63 +55,27 @@ let list_gen =
   let open Gen in
   list_size (10 -- 15) (pair pos_gen data_gen)
 
-let map_gen =
-  let open Gen in
-  let* l = list_gen in
-  return (insert_all l PMap.empty)
-
-let gen_pair = Gen.(pair map_gen (pair pos_gen data_gen))
-
 module S = Set.Make (String)
-
-let elements t =
-  PMap.fold (fun _ d acc -> S.add_seq (PMap.DS.to_seq d) acc) t S.empty
-
-let gen_preserv_arb =
-  make
-    ~print:(fun (map, (p, d)) ->
-      let add = PMap.add p d map in
-      Format.asprintf
-        "data: %a@\n\
-         map:@\n\
-         @[<v 2>Before:@ %a@]@\n\
-         @[<v 2>After:@ %a@]@\n\
-         elements diff:@\n\
-         @[<v>%a@]"
-        PMap.pp_raw (p, d) PMap.pp map PMap.pp add
-        Format.(
-          pp_print_list ~pp_sep:pp_print_cut (fun fmt d ->
-              Format.fprintf fmt "data:%s" d))
-        (let l = S.add d (elements map) in
-         let r = elements add in
-         S.diff l r |> S.elements))
-    gen_pair
-
-let pbt_preservation_test =
-  let insertion_prop (t, (p, d)) =
-    S.equal (S.add d (elements t)) (elements (PMap.add p d t))
-    || Option.is_some (PMap.lookup p t)
-  in
-  QCheck.Test.make ~name:"insertion" ~long_factor:1000 ~count:100_000
-    ~max_fail:0 gen_preserv_arb insertion_prop
 
 let gen_hierarchy_arb =
   make ~shrink:Shrink.list_spine
     ~print:(fun l ->
       List.fold_right
         (fun (p, d) (m, s) ->
-          let after = PMap.add p d m in
-          after, Format.asprintf "trie: %a@\n@\n" PMap.pp after :: s)
-        l (PMap.empty, [])
+          let after = PMap.(add p d m) in
+          ( after,
+            Format.asprintf "tree: %a@\n@\n" PMap.format (PMap.finalize after)
+            :: s ))
+        l (PMap.empty_acc, [])
       |> fun (_, sl) -> String.concat "" (List.rev sl))
     list_gen
 
 let pbt_hierarchy_test =
   let hierarchy_prop l =
-    let t = insert_all l PMap.empty in
-    let rec check (PMap.Trie.Node { itv = (li, i), (lj, j); children; _ }) :
+    let t = insert_all l PMap.empty_acc |> PMap.finalize in
+    let rec check (PMap.Tree.Node { itv = (li, i), (lj, j); children; _ }) :
         bool =
-      let inner (PMap.Trie.Node { itv = (li', i'), (lj', j'); _ } as node) =
+      let inner (PMap.Tree.Node { itv = (li', i'), (lj', j'); _ } as node) =
         (* child node's itv is subset of parent's itv *)
         let b =
           if li < li' && lj > lj' then true
@@ -133,21 +97,17 @@ let mk_pos ?lines sc ec =
   Pos.from_info "dummy" el sc ol ec
 
 let test_commute () =
-  let map = PMap.empty in
+  let map = PMap.empty_acc in
   let inner = PMap.add (mk_pos 1 2) "inner" in
   let outter = PMap.add (mk_pos 1 3) "outter" in
   let before = outter (inner map) in
   let after = inner (outter map) in
-  assert (before = after)
+  assert (PMap.finalize before = PMap.finalize after)
 
 let () =
   let open Tezt.Test in
   register ~__FILE__ ~title:"commutativity" ~tags:["unit"; "ordering"]
     (fun () -> Lwt.return @@ test_commute ());
-  register ~__FILE__ ~title:"PBT: element preservation property"
-    ~tags:["pbt"; "qcheck"; "preserve"] (fun () ->
-      let (Test cell) = pbt_preservation_test in
-      Lwt.return @@ QCheck.Test.check_cell_exn cell);
   register ~__FILE__ ~title:"PBT: hierarchy property"
     ~tags:["pbt"; "qcheck"; "hierarchy"] (fun () ->
       let (Test cell) = pbt_hierarchy_test in


### PR DESCRIPTION
This PR reworks and cleans up the position map structure used to handle hovering queries among others.

After a lot of algorithmic head scratches, the most reasonable solution was, instead of building incrementally, to actually accumulate elements before building the tree in one go. Indeed, we (mostly) insert in surface's position order and, as I encoded the tree as a list (still banging my head on a wall in order to replace that, btw), starting from the last handled element would actually prevent a quadratic factor as we don't have to scan through the whole list each time to insert in the correct position.

This behavior wasn't obvious under normal circumstances (i.e., "normal" size documents) but on extreme examples, we notice an improvement in execution time from >15s to 500ms.