### PR TITLE
Add enum ctor label annotation with combobox display

### DIFF
--- a/catala-atd/catala_types.atd
+++ b/catala-atd/catala_types.atd
@@ -20,6 +20,7 @@ type typ = [
 type enum_declaration = {
   enum_name: string;
   constructors: (string * typ option) list <json repr="object"> <ts repr="map">;
+  ~ctor_attrs: (string * attr_def list) list <json repr="object"> <ts repr="map">;
 }
 
 type struct_declaration = {
@@ -91,6 +92,7 @@ type attr_def = [
   | TestTitle of string
   | Uid of string
   | ArrayItemLabel of string
+  | Description of string
   ] <ocaml repr="classic">
 
 type runtime_value = {

--- a/server/src/main_dap.ml
+++ b/server/src/main_dap.ml
@@ -755,11 +755,11 @@ let () =
     ~contexts:(function
       | Desugared.Name_resolution.ScopeDecl -> true | _ -> false)
     (fun ~pos:_ _ -> Some Nil);
-  Driver.Plugin.register_attribute ~plugin:"testcase" ~path:["array_item_label"]
-    ~contexts:(function
-    | Desugared.Name_resolution.Expression _ -> true
-    | _ -> false)
-  @@ fun ~pos:_ _ -> Some Nil
+  (Driver.Plugin.register_attribute ~plugin:"testcase" ~path:["array_item_label"]
+     ~contexts:(function
+     | Desugared.Name_resolution.Expression _ -> true
+     | _ -> false)
+  @@ fun ~pos:_ _ -> Some Nil)
 
 let main () =
   let rpc = Debug_rpc.create ~in_:Lwt_io.stdin ~out:Lwt_io.stdout () in

--- a/server/src/main_lsp.ml
+++ b/server/src/main_lsp.ml
@@ -73,14 +73,14 @@ let () =
   match value with
   | Shared_ast.String (s, _pos) -> Some (Projects.TestTitle s)
   | _ -> failwith "unexpected test title");
-  Driver.Plugin.register_attribute ~plugin:"testcase" ~path:["array_item_label"]
-    ~contexts:(function
-    | Desugared.Name_resolution.Expression _ -> true
-    | _ -> false)
+  (Driver.Plugin.register_attribute ~plugin:"testcase" ~path:["array_item_label"]
+     ~contexts:(function
+     | Desugared.Name_resolution.Expression _ -> true
+     | _ -> false)
   @@ fun ~pos:_ value ->
   match value with
   | Shared_ast.String (_s, _pos) -> None
-  | _ -> failwith "unexpected array item label"
+  | _ -> failwith "unexpected array item label")
 
 let run () =
   Log.debug (fun m ->

--- a/server/src/projects.ml
+++ b/server/src/projects.ml
@@ -863,6 +863,7 @@ let typ_to_json (decl_ctx : Shared_ast.decl_ctx) (typ : Shared_ast.typ) :
                 let ty = loop ty in
                 let ty = if ty = O.TUnit then None else Some ty in
                 EnumConstructor.to_string cstr, ty);
+          ctor_attrs = []; (* not populated: no current consumer on this path; see Test_case_parser_lib.enum_ctor_attrs for the testcase path *)
         }
     | TArray ty -> O.TArray (loop ty)
     | TOption ty -> O.TOption (loop ty)

--- a/src/editors/Combobox.tsx
+++ b/src/editors/Combobox.tsx
@@ -19,6 +19,7 @@ import {
 export type ComboboxOption = {
   value: string;
   label: string;
+  description?: string;
 };
 
 type ComboboxProps = {
@@ -43,6 +44,7 @@ export function Combobox(props: ComboboxProps): ReactElement {
   const [activeIndex, setActiveIndex] = useState(-1);
 
   const inputRef = useRef<HTMLInputElement>(null);
+  const displayRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLUListElement | null>(null);
 
   const { refs, floatingStyles } = useFloating({
@@ -69,12 +71,20 @@ export function Combobox(props: ComboboxProps): ReactElement {
     whileElementsMounted: autoUpdate,
   });
 
-  const selectedLabel = options.find((o) => o.value === value)?.label ?? '';
+  const selectedOption = options.find((o) => o.value === value);
+  const selectedLabel = selectedOption?.label ?? '';
+  const selectedDescription = selectedOption?.description;
+
+  const showDisplay = !isOpen && !!selectedDescription;
 
   const filtered = filter
-    ? options.filter((o) =>
-        o.label.toLowerCase().includes(filter.toLowerCase())
-      )
+    ? options.filter((o) => {
+        const q = filter.toLowerCase();
+        return (
+          o.label.toLowerCase().includes(q) ||
+          (o.description?.toLowerCase().includes(q) ?? false)
+        );
+      })
     : options;
 
   const open = useCallback(() => {
@@ -82,6 +92,7 @@ export function Combobox(props: ComboboxProps): ReactElement {
     setIsOpen(true);
     setFilter('');
     setActiveIndex(-1);
+    requestAnimationFrame(() => inputRef.current?.focus());
   }, [disabled]);
 
   const close = useCallback(() => {
@@ -94,9 +105,18 @@ export function Combobox(props: ComboboxProps): ReactElement {
     (optionValue: string | null) => {
       onChange(optionValue);
       close();
-      requestAnimationFrame(() => inputRef.current?.focus());
+      const newDescription = options.find(
+        (o) => o.value === optionValue
+      )?.description;
+      requestAnimationFrame(() => {
+        if (newDescription) {
+          displayRef.current?.focus();
+        } else {
+          inputRef.current?.focus();
+        }
+      });
     },
-    [onChange, close]
+    [onChange, close, options]
   );
 
   // Close on outside click — floating listbox is portaled so not inside the reference
@@ -191,22 +211,41 @@ export function Combobox(props: ComboboxProps): ReactElement {
 
   return (
     <div className="combobox" ref={refs.setReference}>
-      <input
-        ref={inputRef}
-        role="combobox"
-        aria-expanded={isOpen}
-        aria-controls={listboxId}
-        aria-activedescendant={activeId}
-        aria-autocomplete="list"
-        value={isOpen ? filter : selectedLabel}
-        placeholder={placeholder}
-        disabled={disabled}
-        onChange={handleInputChange}
-        onKeyDown={handleKeyDown}
-        onClick={() => {
-          if (!isOpen) open();
-        }}
-      />
+      {showDisplay ? (
+        <div
+          ref={displayRef}
+          role="combobox"
+          aria-expanded={false}
+          aria-controls={listboxId}
+          aria-haspopup="listbox"
+          tabIndex={disabled ? -1 : 0}
+          className="combobox-display"
+          onClick={() => {
+            if (!disabled) open();
+          }}
+          onKeyDown={handleKeyDown}
+        >
+          <span className="combobox-display-name">{selectedLabel}</span>
+          <span className="combobox-description">{selectedDescription}</span>
+        </div>
+      ) : (
+        <input
+          ref={inputRef}
+          role="combobox"
+          aria-expanded={isOpen}
+          aria-controls={listboxId}
+          aria-activedescendant={activeId}
+          aria-autocomplete="list"
+          value={isOpen ? filter : selectedLabel}
+          placeholder={placeholder}
+          disabled={disabled}
+          onChange={handleInputChange}
+          onKeyDown={handleKeyDown}
+          onClick={() => {
+            if (!isOpen) open();
+          }}
+        />
+      )}
       <button
         className="combobox-toggle"
         tabIndex={-1}
@@ -217,7 +256,6 @@ export function Combobox(props: ComboboxProps): ReactElement {
             close();
           } else {
             open();
-            requestAnimationFrame(() => inputRef.current?.focus());
           }
         }}
       >
@@ -256,7 +294,12 @@ export function Combobox(props: ComboboxProps): ReactElement {
                 }}
                 onMouseEnter={() => setActiveIndex(i)}
               >
-                {option.label}
+                <span className="combobox-option-label">{option.label}</span>
+                {option.description && (
+                  <span className="combobox-description">
+                    {option.description}
+                  </span>
+                )}
               </li>
             ))}
           </ul>,

--- a/src/editors/ValueEditors.tsx
+++ b/src/editors/ValueEditors.tsx
@@ -228,6 +228,7 @@ export default function ValueEditor(props: Props): ReactElement {
       const option_decl: EnumDeclaration = {
         enum_name: 'Optional',
         constructors,
+        ctor_attrs: new Map(),
       };
       editor = (
         <EnumEditor
@@ -1045,7 +1046,12 @@ function EnumEditor(props: EnumEditorProps): ReactElement {
   // Note: do not early-return here; we render the expected editor and, when applicable,
   // an "actual preview" block alongside it further below.
   const ctorOptions = Array.from(enumDeclaration.constructors.keys()).map(
-    (name) => ({ value: name, label: name })
+    (name) => {
+      const labelAttr = enumDeclaration.ctor_attrs
+        .get(name)
+        ?.find((a) => a.kind === 'Description');
+      return { value: name, label: name, description: labelAttr?.value };
+    }
   );
 
   const handleCtorChange = (selected: string | null): void => {

--- a/src/generated/catala_types.ts
+++ b/src/generated/catala_types.ts
@@ -33,6 +33,7 @@ export type Typ =
 export type EnumDeclaration = {
   enum_name: string;
   constructors: Map<string, Option<Typ>>;
+  ctor_attrs: Map<string, AttrDef[]>;
 }
 
 export type StructDeclaration = {
@@ -93,6 +94,7 @@ export type AttrDef =
 | { kind: 'TestTitle'; value: string }
 | { kind: 'Uid'; value: string }
 | { kind: 'ArrayItemLabel'; value: string }
+| { kind: 'Description'; value: string }
 
 export type RuntimeValue = {
   value: RuntimeValueRaw;
@@ -356,6 +358,7 @@ export function writeEnumDeclaration(x: EnumDeclaration, context: any = x): any 
   return {
     'enum_name': _atd_write_required_field('EnumDeclaration', 'enum_name', _atd_write_string, x.enum_name, x),
     'constructors': _atd_write_required_field('EnumDeclaration', 'constructors', _atd_write_assoc_map_to_object(_atd_write_option(writeTyp)), x.constructors, x),
+    'ctor_attrs': _atd_write_field_with_default(_atd_write_assoc_map_to_object(_atd_write_array(writeAttrDef)), new Map(), x.ctor_attrs, x),
   };
 }
 
@@ -363,6 +366,7 @@ export function readEnumDeclaration(x: any, context: any = x): EnumDeclaration {
   return {
     enum_name: _atd_read_required_field('EnumDeclaration', 'enum_name', _atd_read_string, x['enum_name'], x),
     constructors: _atd_read_required_field('EnumDeclaration', 'constructors', _atd_read_assoc_object_into_map(_atd_read_option(readTyp)), x['constructors'], x),
+    ctor_attrs: _atd_read_field_with_default(_atd_read_assoc_object_into_map(_atd_read_array(readAttrDef)), new Map(), x['ctor_attrs'], x),
   };
 }
 
@@ -549,6 +553,8 @@ export function writeAttrDef(x: AttrDef, context: any = x): any {
       return ['Uid', _atd_write_string(x.value, x)]
     case 'ArrayItemLabel':
       return ['ArrayItemLabel', _atd_write_string(x.value, x)]
+    case 'Description':
+      return ['Description', _atd_write_string(x.value, x)]
   }
 }
 
@@ -563,6 +569,8 @@ export function readAttrDef(x: any, context: any = x): AttrDef {
       return { kind: 'Uid', value: _atd_read_string(x[1], x) }
     case 'ArrayItemLabel':
       return { kind: 'ArrayItemLabel', value: _atd_read_string(x[1], x) }
+    case 'Description':
+      return { kind: 'Description', value: _atd_read_string(x[1], x) }
     default:
       _atd_bad_json('AttrDef', x, context)
       throw new Error('impossible')

--- a/src/styles/combobox.css
+++ b/src/styles/combobox.css
@@ -9,6 +9,32 @@
   padding-right: 28px; /* room for toggle button */
 }
 
+.combobox-display {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  overflow: hidden;
+  padding: var(--spacing8) 28px var(--spacing8) var(--spacing16);
+  box-sizing: border-box;
+  cursor: pointer;
+  border: 1px solid var(--control-border, transparent);
+  outline: none;
+}
+
+.combobox-display:focus {
+  outline: 1px solid var(--vscode-focusBorder, #007fd4);
+  outline-offset: -1px;
+}
+
+.combobox-display-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 0;
+  max-width: 60%;
+}
+
 .combobox-toggle {
   position: absolute;
   right: 1px;
@@ -52,6 +78,24 @@
   padding: 4px 8px;
   cursor: pointer;
   font-size: 13px;
+}
+
+.combobox-description {
+  font-size: 11px;
+  opacity: 0.7;
+  font-style: italic;
+}
+
+.combobox-option .combobox-description {
+  display: block;
+  margin-top: 1px;
+}
+
+.combobox-display .combobox-description {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 1;
 }
 
 .combobox-option.active {

--- a/src/styles/theme-variables.css
+++ b/src/styles/theme-variables.css
@@ -175,6 +175,7 @@ input {
 
 .vscode-dark .value-editor input,
 .vscode-dark .value-editor select,
+.vscode-dark .value-editor .combobox-display,
 .vscode-dark .value-editor,
 .vscode-dark .assertion-editor {
   background-color: var(--stormgray925);
@@ -236,6 +237,7 @@ input {
 
 .vscode-light .value-editor input,
 .vscode-light .value-editor select,
+.vscode-light .value-editor .combobox-display,
 .vscode-light .struct-editor .value-editor,
 .vscode-light .assertion-editor {
   background-color: var(--stormgray00);

--- a/test-case-parser/test_case_parser_lib.ml
+++ b/test-case-parser/test_case_parser_lib.ml
@@ -199,6 +199,7 @@ let mk_optional_enum_decl lang typ =
   {
     O.enum_name = EnumName.to_string ConstantNames.option_enum;
     constructors = ["Absent", None; (get_lang_strings lang).present, Some typ];
+    ctor_attrs = [];
   }
 
 let get_typ_literal = function
@@ -252,6 +253,19 @@ and get_struct lang decl_ctx struct_name =
   in
   { O.struct_name; fields }
 
+and enum_ctor_attrs constr_map =
+  List.filter_map
+    (fun (constr, _) ->
+      let pos = EnumConstructor.get_info constr |> snd in
+      let attrs =
+        Pos.get_attrs pos (function
+          | Description s -> Some (O.Description s)
+          | _ -> None)
+      in
+      if attrs = [] then None
+      else Some (EnumConstructor.to_string constr, attrs))
+    (EnumConstructor.Map.bindings constr_map)
+
 and get_enum (lang : Global.backend_lang) (decl_ctx : decl_ctx) enum_name =
   let constr_map = EnumName.Map.find enum_name decl_ctx.ctx_enums in
   if EnumName.equal enum_name ConstantNames.option_enum then
@@ -275,6 +289,7 @@ and get_enum (lang : Global.backend_lang) (decl_ctx : decl_ctx) enum_name =
         let alias_opt = lookup_aliased_name lang module_name in
         Option.(some (value alias_opt ~default:module_name))
     in
+    let bindings = EnumConstructor.Map.bindings constr_map in
     let constructors =
       List.map
         (fun (constr, typ) ->
@@ -282,14 +297,15 @@ and get_enum (lang : Global.backend_lang) (decl_ctx : decl_ctx) enum_name =
             match typ with
             | TLit TUnit, _ -> None
             | _ -> Some (get_typ lang decl_ctx typ) ))
-        (EnumConstructor.Map.bindings constr_map)
+        bindings
     in
+    let ctor_attrs = enum_ctor_attrs constr_map in
     let enum_name =
       match module_name with
       | None -> EnumName.base enum_name
       | Some s -> Format.asprintf "%s.%s" s (EnumName.base enum_name)
     in
-    { O.enum_name; constructors }
+    { O.enum_name; constructors; ctor_attrs }
 
 type Pos.attr += TestUi
 type Pos.attr += Uid of string
@@ -349,6 +365,7 @@ let rec get_value : type a.
           {
             O.enum_name = EnumName.to_string ConstantNames.option_enum;
             constructors = [none_field];
+            ctor_attrs = [];
           }
         in
         O.Enum (decl, none_field)
@@ -370,6 +387,7 @@ let rec get_value : type a.
           {
             O.enum_name = EnumName.to_string ConstantNames.option_enum;
             constructors = [some_field];
+            ctor_attrs = [];
           }
         in
         O.Enum (decl, some_value))
@@ -614,11 +632,12 @@ let patch_paths
     else Format.sprintf "%s.%s" (ModuleName.to_string modl) s
   in
   let rec patch_enum_decl = function
-    | { O.enum_name; constructors } ->
+    | { O.enum_name; constructors; ctor_attrs } ->
       {
         enum_name = patch_name enum_name;
         constructors =
           List.map (fun (c, t) -> c, Option.map patch_typ t) constructors;
+        ctor_attrs;
       }
   and patch_struct_decl = function
     | { struct_name; fields } ->
@@ -1032,13 +1051,13 @@ let rec print_catala_value ~(typ : O.typ option) ~lang ppf (v : O.runtime_value)
                 (fun ppf -> fprintf ppf "%d %s" days strings.duration_units.day)
             else None);
          ])
-  | _, O.Enum ({ enum_name = "Optional"; constructors }, (constr, v)) ->
+  | _, O.Enum ({ enum_name = "Optional"; constructors; _ }, (constr, v)) ->
     if v = None then fprintf ppf "Absent"
     else
       fprintf ppf "%s %s %a" strings.present strings.content_str
         (print_catala_value ~typ:(List.assoc constr constructors) ~lang)
         (Option.get v)
-  | Some (TEnum { enum_name; constructors }), O.Enum (_en, (constr, Some v)) ->
+  | Some (TEnum { enum_name; constructors; _ }), O.Enum (_en, (constr, Some v)) ->
     fprintf ppf "@[<hv 2>%s.%s %s %a@]" enum_name constr strings.content_str
       (print_catala_value ~typ:(List.assoc constr constructors) ~lang)
       v

--- a/test-case-parser/testcase.ml
+++ b/test-case-parser/testcase.ml
@@ -145,13 +145,13 @@ let register () =
   match value with
   | Shared_ast.String (s, _pos) -> Some (Test_case_parser_lib.TestTitle s)
   | _ -> failwith "unexpected test title");
-  Driver.Plugin.register_attribute ~plugin:"testcase" ~path:["array_item_label"]
-    ~contexts:(function
-    | Desugared.Name_resolution.Expression _ -> true
-    | _ -> false)
+  (Driver.Plugin.register_attribute ~plugin:"testcase" ~path:["array_item_label"]
+     ~contexts:(function
+     | Desugared.Name_resolution.Expression _ -> true
+     | _ -> false)
   @@ fun ~pos:_ value ->
   match value with
   | Shared_ast.String (s, _pos) -> Some (Test_case_parser_lib.ArrayItemLabel s)
-  | _ -> failwith "unexpected array item label"
+  | _ -> failwith "unexpected array item label")
 
 let () = register ()

--- a/tests/editors/complex-structures.spec.tsx
+++ b/tests/editors/complex-structures.spec.tsx
@@ -97,6 +97,7 @@ describe('Tier 1: Array within enum payload', () => {
         },
       ],
     ]),
+    ctor_attrs: new Map(),
   };
 
   // Record { id: int, status: Status }
@@ -255,6 +256,7 @@ describe('Tier 1: Array of enums with struct payloads', () => {
       ['Stopped', null],
       ['Error', { value: { kind: 'TStruct', value: infoStructDecl } }],
     ]),
+    ctor_attrs: new Map(),
   };
 
   // Log { timestamp: date, events: Event[] }
@@ -337,6 +339,7 @@ describe('Tier 2: Deeply nested structure (4 levels)', () => {
       ['Developer', null],
       ['Intern', null],
     ]),
+    ctor_attrs: new Map(),
   };
 
   // Member { id: int, role: Role }
@@ -468,6 +471,7 @@ describe('Tier 2: Mixed primitive and complex fields', () => {
       ['Medium', null],
       ['High', { value: { kind: 'TDate' } }],
     ]),
+    ctor_attrs: new Map(),
   };
 
   // Metadata { version: int, active: bool }

--- a/tests/editors/subtable-back-navigation.spec.tsx
+++ b/tests/editors/subtable-back-navigation.spec.tsx
@@ -49,6 +49,8 @@ describe('TableArrayEditor - Sub-table back navigation', () => {
         ['Manager', null],
         ['Developer', null],
       ]),
+
+      ctor_attrs: new Map(),
     };
 
     // Member { id: int, role: Role }

--- a/tests/editors/subtable-pill-navigation.spec.tsx
+++ b/tests/editors/subtable-pill-navigation.spec.tsx
@@ -45,6 +45,8 @@ describe('TableArrayEditor - Pill navigation highlighting', () => {
         ['Manager', null],
         ['Developer', null],
       ]),
+
+      ctor_attrs: new Map(),
     };
 
     // Member { id: int, role: Role }

--- a/tests/editors/table-view-eligibility.spec.tsx
+++ b/tests/editors/table-view-eligibility.spec.tsx
@@ -97,6 +97,8 @@ describe('structIsFlattenable - detection logic', () => {
           ['Inactive', null],
           ['Pending', { value: { kind: 'TDate' } }],
         ]),
+
+        ctor_attrs: new Map(),
       };
 
       const structDecl: StructDeclaration = {
@@ -151,6 +153,8 @@ describe('structIsFlattenable - detection logic', () => {
             },
           ],
         ]),
+
+        ctor_attrs: new Map(),
       };
 
       const orderDecl: StructDeclaration = {
@@ -186,6 +190,8 @@ describe('structIsFlattenable - detection logic', () => {
           ],
           ['Inactive', null],
         ]),
+
+        ctor_attrs: new Map(),
       };
 
       // Inner { status: Status }
@@ -284,6 +290,8 @@ describe('structIsFlattenable - detection logic', () => {
           ['Stopped', null],
           ['Error', { value: { kind: 'TStruct', value: infoDecl } }],
         ]),
+
+        ctor_attrs: new Map(),
       };
 
       // Log { timestamp: date, events: Event[] }
@@ -310,6 +318,8 @@ describe('structIsFlattenable - detection logic', () => {
           ['Inactive', null],
           ['PendingUntil', { value: { kind: 'TDate' } }],
         ]),
+
+        ctor_attrs: new Map(),
       };
 
       // Record { id: int, statuses: Status[] }
@@ -352,6 +362,8 @@ describe('TableArrayEditor - TArray<enum> sub-table rendering', () => {
         ['P', null],
         ['D', null],
       ]),
+
+      ctor_attrs: new Map(),
     };
 
     // Personne_PDN { id: int, droits_au_séjour: Code_titre_droit_sejour[] }
@@ -571,6 +583,8 @@ describe('ArrayEditor - table view eligibility', () => {
             },
           ],
         ]),
+
+        ctor_attrs: new Map(),
       };
 
       const orderDecl: StructDeclaration = {
@@ -663,6 +677,8 @@ describe('ArrayEditor - table view eligibility', () => {
             },
           ],
         ]),
+
+        ctor_attrs: new Map(),
       };
 
       const orderDecl: StructDeclaration = {
@@ -732,6 +748,8 @@ describe('ArrayEditor - table view eligibility', () => {
           ['Stopped', null],
           ['Error', { value: { kind: 'TStruct', value: infoDecl } }],
         ]),
+
+        ctor_attrs: new Map(),
       };
 
       const logDecl: StructDeclaration = {

--- a/tests/enum-accept.ui.spec.tsx
+++ b/tests/enum-accept.ui.spec.tsx
@@ -29,6 +29,7 @@ describe('AssertionValueEditor - Enum accept button', () => {
         ['A', null],
         ['B', { value: { kind: 'TStruct', value: structDecl } }],
       ]),
+      ctor_attrs: new Map(),
     };
     const enumTyp: Typ = { kind: 'TEnum', value: enumDecl };
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -14,7 +14,10 @@ export function tStruct(name: string, fields: Map<string, Typ>): Typ {
 }
 
 export function tEnum(name: string, ctors: Map<string, Option<Typ>>): Typ {
-  return { kind: 'TEnum', value: { enum_name: name, constructors: ctors } };
+  return {
+    kind: 'TEnum',
+    value: { enum_name: name, constructors: ctors, ctor_attrs: new Map() },
+  };
 }
 
 export function tRat(): Typ {


### PR DESCRIPTION
Given a `label` annotation on an enum declaration:

```
déclaration énumération ZoneDHabitation:
  #[testcase.label = "Paris"]
  -- Zone1
  #[testcase.label = "Départements limitrophes"]
  -- Zone2
  #[testcase.label = "Autres Destinations / Interplanétaire"]
  -- Zone3
```

This PR will show the UI below in the testcase editor:

<img width="633" height="314" alt="image" src="https://github.com/user-attachments/assets/6ea84607-174b-4b56-9491-12a8c9abf4f9" />

The annotations' text will be searchable in the combobox (e.g. it's possible to filter for "Paris" in the enum above) as well as the constructors names.

Given the fact that we're in a plugin, the `label` annotation is still scoped to `testcase`. We could make it a built-in ("compiler-level") annotation as suggested in https://github.com/CatalaLang/catala-book/pull/62