### PR TITLE
Show array item label in tree/card view

### DIFF
--- a/src/editors/ArrayEditor.tsx
+++ b/src/editors/ArrayEditor.tsx
@@ -25,7 +25,11 @@ import {
 import { confirm } from '../messaging/confirm';
 import { TableArrayEditor } from './TableArrayEditor';
 import { getTypeDisplayName } from './typeNameUtils';
-import { tryCreateTableSchema } from './tableArrayUtils';
+import {
+  tryCreateTableSchema,
+  getArrayItemLabel,
+  setArrayItemLabel,
+} from './tableArrayUtils';
 
 /**
  * Diffs are consumed only by ArrayEditor to compute "phantom" indices
@@ -134,6 +138,14 @@ export function ArrayEditor(props: ArrayEditorProps): ReactElement {
     const newArray = currentArray.filter((_, i) => i !== index);
     updateParent(newArray);
     invalidateArrayDiffs();
+  };
+
+  const handleLabelChange = (index: number, newLabel: string): void => {
+    const item = currentArray[index];
+    handleUpdate(index, {
+      ...item,
+      attrs: setArrayItemLabel(item.attrs, newLabel),
+    });
   };
 
   const handleMove = (fromIndex: number, toIndex: number): void => {
@@ -294,6 +306,24 @@ export function ArrayEditor(props: ArrayEditorProps): ReactElement {
             // Delete-last only (path-stable)
             const canRemove = canRemoveLast(currentArray.length, index);
 
+            const labelInput = !isPhantom ? (
+              <input
+                type="text"
+                className={`row-label-input${!isVertical ? ' array-item-label' : ''}`}
+                value={getArrayItemLabel(item?.attrs) ?? ''}
+                onChange={(e) => handleLabelChange(index, e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === 'Escape')
+                    (e.target as HTMLInputElement).blur();
+                }}
+                placeholder={intl.formatMessage({
+                  id: 'tableEditor.labelPlaceholder',
+                  defaultMessage: 'Name...',
+                })}
+                disabled={!editable}
+              />
+            ) : null;
+
             return (
               <div
                 key={itemKey}
@@ -306,10 +336,14 @@ export function ArrayEditor(props: ArrayEditorProps): ReactElement {
               >
                 <div className="array-item-content">
                   {isVertical && (
-                    <h2 className="array-item-header heading-h2">
-                      {getTypeDisplayName(elementType, intl)}
-                    </h2>
+                    <div className="array-item-header">
+                      <h2 className="heading-h2">
+                        {getTypeDisplayName(elementType, intl)}
+                      </h2>
+                      {labelInput}
+                    </div>
                   )}
+                  {!isVertical && labelInput}
                   {isPhantom &&
                   indexDiff &&
                   isEmptyValue(indexDiff.expected) &&

--- a/src/styles/array-editor.css
+++ b/src/styles/array-editor.css
@@ -50,6 +50,22 @@
   max-width: 100%;
 }
 
+.array-item-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing8);
+  margin-bottom: var(--spacing8);
+}
+
+.array-item-header .row-label-input {
+  flex: 1;
+}
+
+.array-item-label {
+  display: block;
+  margin-bottom: var(--spacing8);
+}
+
 .array-item-controls {
   display: flex;
   gap: 2px;

--- a/src/styles/array-editor.css
+++ b/src/styles/array-editor.css
@@ -66,6 +66,13 @@
   margin-bottom: var(--spacing8);
 }
 
+/* Specificity override: .struct-editor input (0,2,1) beats .row-label-input (0,1,0) */
+.array-item-content input.row-label-input {
+  border: none;
+  border-bottom: 1px dashed transparent;
+  padding: 2px 4px;
+}
+
 .array-item-controls {
   display: flex;
   gap: 2px;

--- a/src/styles/array-editor.css
+++ b/src/styles/array-editor.css
@@ -66,13 +66,6 @@
   margin-bottom: var(--spacing8);
 }
 
-/* Specificity override: .struct-editor input (0,2,1) beats .row-label-input (0,1,0) */
-.array-item-content input.row-label-input {
-  border: none;
-  border-bottom: 1px dashed transparent;
-  padding: 2px 4px;
-}
-
 .array-item-controls {
   display: flex;
   gap: 2px;

--- a/src/styles/combobox.css
+++ b/src/styles/combobox.css
@@ -45,6 +45,7 @@
     --vscode-dropdown-foreground,
     var(--vscode-input-foreground, inherit)
   );
+  z-index: 100;
 }
 
 .combobox-option {

--- a/src/styles/theme-variables.css
+++ b/src/styles/theme-variables.css
@@ -175,10 +175,8 @@ input {
 
 .vscode-dark .value-editor input,
 .vscode-dark .value-editor select,
-.vscode-dark .struct-editor input,
 .vscode-dark .value-editor,
-.vscode-dark .assertion-editor,
-.vscode-dark .struct-editor select {
+.vscode-dark .assertion-editor {
   background-color: var(--stormgray925);
   color: var(--stormgray500);
   border-color: var(--stormgray800);
@@ -238,10 +236,8 @@ input {
 
 .vscode-light .value-editor input,
 .vscode-light .value-editor select,
-.vscode-light .struct-editor input,
 .vscode-light .struct-editor .value-editor,
-.vscode-light .assertion-editor,
-.vscode-light .struct-editor select {
+.vscode-light .assertion-editor {
   background-color: var(--stormgray00);
   color: var(--stormgray900);
   border-color: var(--stormgray300);

--- a/src/styles/value-editors.css
+++ b/src/styles/value-editors.css
@@ -1,8 +1,6 @@
 /* Common input styles */
 .value-editor input,
-.value-editor select,
-.struct-editor input,
-.struct-editor select {
+.value-editor select {
   width: 100%;
   padding: var(--spacing8) var(--spacing16) var(--spacing8) var(--spacing16);
   border: 1px solid;
@@ -12,9 +10,7 @@
 }
 
 .value-editor input:focus,
-.value-editor select:focus,
-.struct-editor input:focus,
-.struct-editor select:focus {
+.value-editor select:focus {
   outline: none;
   border-color: var(--tab-active-border);
 }

--- a/tests/editors/array-item-label.spec.tsx
+++ b/tests/editors/array-item-label.spec.tsx
@@ -11,17 +11,9 @@ import { ArrayEditor } from '../../src/editors/ArrayEditor';
 import { rv, arrayVal } from './test-helpers';
 import enMessages from '../../src/locales/en.json';
 
-// Struct with a TOption<TArray<TInt>> field:
-//   - tryCreateTableSchema fails (option-wrapping-array is unsupported)
-//   - hasNestedArrays = true → vertical layout → label input in the item header
 const decl: StructDeclaration = {
   struct_name: 'S',
-  fields: new Map<string, Typ>([
-    [
-      'f',
-      { kind: 'TOption', value: { kind: 'TArray', value: { kind: 'TInt' } } },
-    ],
-  ]),
+  fields: new Map<string, Typ>([['f', { kind: 'TInt' }]]),
 };
 const elementType: Typ = { kind: 'TStruct', value: decl };
 
@@ -74,11 +66,32 @@ describe('array item label input', () => {
     expect(onValueChange).toHaveBeenCalled();
     const updatedRV: RuntimeValue = onValueChange.mock.calls[0][0];
     expect(updatedRV.value.kind).toBe('Array');
-    const updatedAttrs =
-      updatedRV.value.kind === 'Array'
-        ? (updatedRV.value.value[0]?.attrs ?? [])
-        : [];
-    const labelAttr = updatedAttrs.find((a) => a.kind === 'ArrayItemLabel');
+    if (updatedRV.value.kind !== 'Array') throw new Error('unreachable');
+    const labelAttr = updatedRV.value.value[0]?.attrs?.find(
+      (a) => a.kind === 'ArrayItemLabel'
+    );
     expect(labelAttr?.kind === 'ArrayItemLabel' && labelAttr.value).toBe('new');
+  });
+
+  it('disables the label input when editable is false', () => {
+    setup([makeItem()]);
+    const inputs = screen.getAllByPlaceholderText('Name...');
+    expect(inputs[0]).not.toBeDisabled();
+
+    const onValueChange = vi.fn();
+    render(
+      <IntlProvider locale="en" messages={enMessages}>
+        <ArrayEditor
+          elementType={elementType}
+          valueDef={{ value: arrayVal([makeItem()]) }}
+          onValueChange={onValueChange}
+          currentPath={[]}
+          diffs={[]}
+          editable={false}
+        />
+      </IntlProvider>
+    );
+    const allInputs = screen.getAllByPlaceholderText('Name...');
+    expect(allInputs[allInputs.length - 1]).toBeDisabled();
   });
 });

--- a/tests/editors/array-item-label.spec.tsx
+++ b/tests/editors/array-item-label.spec.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import type {
+  RuntimeValue,
+  StructDeclaration,
+  Typ,
+} from '../../src/generated/catala_types';
+import { ArrayEditor } from '../../src/editors/ArrayEditor';
+import { rv, arrayVal } from './test-helpers';
+import enMessages from '../../src/locales/en.json';
+
+// Struct with a TOption<TArray<TInt>> field:
+//   - tryCreateTableSchema fails (option-wrapping-array is unsupported)
+//   - hasNestedArrays = true → vertical layout → label input in the item header
+const decl: StructDeclaration = {
+  struct_name: 'S',
+  fields: new Map<string, Typ>([
+    [
+      'f',
+      { kind: 'TOption', value: { kind: 'TArray', value: { kind: 'TInt' } } },
+    ],
+  ]),
+};
+const elementType: Typ = { kind: 'TStruct', value: decl };
+
+function makeItem(label?: string): RuntimeValue {
+  const attrs: RuntimeValue['attrs'] = [
+    { kind: 'Uid', value: crypto.randomUUID() },
+  ];
+  if (label !== undefined) attrs.push({ kind: 'ArrayItemLabel', value: label });
+  return {
+    value: {
+      kind: 'Struct',
+      value: [decl, new Map([['f', rv({ kind: 'Unset' })]])],
+    },
+    attrs,
+  };
+}
+
+function setup(items: RuntimeValue[]) {
+  const onValueChange = vi.fn();
+  render(
+    <IntlProvider locale="en" messages={enMessages}>
+      <ArrayEditor
+        elementType={elementType}
+        valueDef={{ value: arrayVal(items) }}
+        onValueChange={onValueChange}
+        currentPath={[]}
+        diffs={[]}
+      />
+    </IntlProvider>
+  );
+  return { onValueChange };
+}
+
+describe('array item label input', () => {
+  it('renders a label input for each non-phantom item', () => {
+    setup([makeItem(), makeItem()]);
+    const inputs = screen.getAllByPlaceholderText('Name...');
+    expect(inputs).toHaveLength(2);
+  });
+
+  it('shows existing label value in the input', () => {
+    setup([makeItem('my label')]);
+    expect(screen.getByDisplayValue('my label')).toBeInTheDocument();
+  });
+
+  it('calls onValueChange with updated ArrayItemLabel attr on input change', () => {
+    const { onValueChange } = setup([makeItem('old')]);
+    const input = screen.getByDisplayValue('old');
+    fireEvent.change(input, { target: { value: 'new' } });
+    expect(onValueChange).toHaveBeenCalled();
+    const updatedRV: RuntimeValue = onValueChange.mock.calls[0][0];
+    expect(updatedRV.value.kind).toBe('Array');
+    const updatedAttrs =
+      updatedRV.value.kind === 'Array'
+        ? (updatedRV.value.value[0]?.attrs ?? [])
+        : [];
+    const labelAttr = updatedAttrs.find((a) => a.kind === 'ArrayItemLabel');
+    expect(labelAttr?.kind === 'ArrayItemLabel' && labelAttr.value).toBe('new');
+  });
+});


### PR DESCRIPTION
Custom array element labels were provided in the table view, but were absent from the tree view. This PR ensures feature parity between views.