### PR TITLE
explain graph in vscode extension via lsp-server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "catala",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "catala",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",
@@ -15,6 +15,8 @@
         "@types/vscode-webview": "^1.57.5",
         "@vscode/codicons": "^0.0.36",
         "command-exists": "^1.2.9",
+        "d3": "^7.9.0",
+        "d3-graphviz": "^5.6.0",
         "p-queue": "^6.6.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -25,6 +27,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
         "@types/command-exists": "^1.2.3",
+        "@types/d3-graphviz": "^2.6.10",
         "@types/mocha": "^10.0.6",
         "@types/node": "^22.19.1",
         "@types/vscode": "^1.86.0",
@@ -1211,6 +1214,137 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@hpcc-js/wasm": {
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/@hpcc-js/wasm/-/wasm-2.34.0.tgz",
+      "integrity": "sha512-i1EHldV1xIvjzp7VFOS7jQOOZotkb9Wx0fsSYhR8KLtPhmUe17OxlQNxU9FMrlEQbVlHUsDqY8W0vwkyHURqJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "yargs": "18.0.0"
+      },
+      "bin": {
+        "dot-wasm": "deprecated/dot-wasm.js"
+      }
+    },
+    "node_modules/@hpcc-js/wasm/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@hpcc-js/wasm/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@hpcc-js/wasm/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@hpcc-js/wasm/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/@hpcc-js/wasm/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@hpcc-js/wasm/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@hpcc-js/wasm/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@hpcc-js/wasm/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@hpcc-js/wasm/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2197,6 +2331,63 @@
       "version": "1.2.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.4.5.tgz",
+      "integrity": "sha512-5sNP3DmtSnSozxcjqmzQKsDOuVJXZkceo1KJScDc1982kk/TS9mTPc6lpli1gTu1MIBF1YWutpHpjucNWcIj5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-graphviz": {
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-graphviz/-/d3-graphviz-2.6.10.tgz",
+      "integrity": "sha512-YsCRqNqS8QLlsKtF0FGIz42Z47B0sBIxMMn7L4ZdqZcrdk4foJOEPwwMH50Qe2PuZmSSZcWbdgUnj5W68xK0Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "^1",
+        "@types/d3-transition": "^1",
+        "@types/d3-zoom": "^1"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-1.4.5.tgz",
+      "integrity": "sha512-k9L18hXXv7OvK4PqW1kSFYIzasGOvfhPUWmHFkoZ8/ci99EAmY4HoF6zMefrHl0SGV7XYc7Qq2MNh8dK3edg5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "^1"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.4.7.tgz",
+      "integrity": "sha512-aLaTOjdOJEFPhij59NdNwppvpHBheZFlLbcb7cIZZYLC0he9Wmdd/u4+1NZxlr7ncK+mq1PLmowMPw1GONrIQg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-1.3.6.tgz",
+      "integrity": "sha512-Y8NwxuHV4ElbCkN7tJcuwENYKiAL+ktU6tNDLHqZ141YsaT3kwa5ZA5eqiJwHYWQzXMjF+FgL6/Sxo9IGSwmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "^1"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-1.8.7.tgz",
+      "integrity": "sha512-HJWci3jXwFIuFKDqGn5PmuwrhZvuFdrnUmtSKCLXFAWyf2lAIUKMKh1/lHOkWBl/f4KVupGricJiqkQy+cVTog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "^1",
+        "@types/d3-selection": "^1"
+      }
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
@@ -4108,6 +4299,438 @@
       "version": "3.1.3",
       "license": "MIT"
     },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-graphviz": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/d3-graphviz/-/d3-graphviz-5.6.0.tgz",
+      "integrity": "sha512-46OOyRv5Ioo9kZBc919FVIYPD/ObtdSZxOK1hv+qwmD7TunpPvvmsI1dSdxhVgH4GragJxFZ31+TQC5aOuXzzw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hpcc-js/wasm": "^2.20.0",
+        "d3-dispatch": "^3.0.1",
+        "d3-format": "^3.1.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-path": "^3.1.0",
+        "d3-timer": "^3.0.1",
+        "d3-transition": "^3.0.1",
+        "d3-zoom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "d3-selection": "^3.0.0"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -4231,6 +4854,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -4569,7 +5201,6 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5175,7 +5806,6 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -5183,7 +5813,6 @@
     },
     "node_modules/get-east-asian-width": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5558,7 +6187,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -5692,6 +6320,15 @@
       "dev": true,
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/interpret": {
       "version": "3.1.1",
@@ -8210,6 +8847,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.53.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
@@ -8296,6 +8939,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "dev": true,
@@ -8319,7 +8968,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/sax": {
@@ -10011,7 +10659,6 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -80,6 +80,10 @@
         "command": "catala.showExceptionsAtCursor",
         "title": "%command.catala.showExceptionsAtCursor.title%",
         "category": "%category.catala%"
+      },
+      {
+        "command": "catala.explain",
+        "title": "%command.catala.explain.title%"
       }
     ],
     "menus": {
@@ -369,6 +373,8 @@
     "@types/vscode-webview": "^1.57.5",
     "@vscode/codicons": "^0.0.36",
     "command-exists": "^1.2.9",
+    "d3": "^7.9.0",
+    "d3-graphviz": "^5.6.0",
     "p-queue": "^6.6.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -379,6 +385,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@types/command-exists": "^1.2.3",
+    "@types/d3-graphviz": "^2.6.10",
     "@types/mocha": "^10.0.6",
     "@types/node": "^22.19.1",
     "@types/vscode": "^1.86.0",

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -4,5 +4,6 @@
   "command.catala.showExceptionsAtCursor.title": "Afficher l'arbre de définitions",
   "view.catala.exceptionsView.name": "Arbre de définitions",
   "category.catala": "Catala",
-  "customEditor.testCaseEditor.displayName": "Éditeur de cas de test Catala"
+  "customEditor.testCaseEditor.displayName": "Éditeur de cas de test Catala",
+  "command.catala.explain.title": "Expliquer"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -4,5 +4,6 @@
   "command.catala.showExceptionsAtCursor.title": "Show definition tree",
   "view.catala.exceptionsView.name": "Definition tree",
   "category.catala": "Catala",
-  "customEditor.testCaseEditor.displayName": "Catala Test Case Editor"
+  "customEditor.testCaseEditor.displayName": "Catala Test Case Editor",
+  "command.catala.explain.title": "Explain"
 }

--- a/server/src/doc_queries.ml
+++ b/server/src/doc_queries.ml
@@ -302,6 +302,9 @@ let lookup_document_symbols file =
         vl acc)
     jt.pos_map []
 
+(* check if the explain plugin is available, set in Server.on_req_code_lens *)
+let explain_plugin_available : bool option ref = ref None
+
 let lookup_lenses file =
   let*? { jump_table = (lazy jt); _ } = file.last_valid_result in
   (* we consider only the including file's document id if the document is
@@ -329,10 +332,20 @@ let lookup_lenses file =
     let debug_command =
       Command.create ~arguments ~command:"catala.debugScope" ~title:"🛠 Debug" ()
     in
-    [
-      CodeLens.create ~command:run_command ~range ();
-      CodeLens.create ~command:debug_command ~range ();
-    ]
+    let lenses =
+      [
+        CodeLens.create ~command:run_command ~range ();
+        CodeLens.create ~command:debug_command ~range ();
+      ]
+    in
+    (* Only offer "Explain" when the [explain] plugin is available. *)
+    if !explain_plugin_available = Some true then
+      let explain_command =
+        Command.create ~arguments ~command:"catala.explainScope"
+          ~title:"? Explain" ()
+      in
+      lenses @ [CodeLens.create ~command:explain_command ~range ()]
+    else lenses
   in
   let mk_input_lens scope range =
     let arguments =

--- a/server/src/doc_queries.mli
+++ b/server/src/doc_queries.mli
@@ -56,6 +56,8 @@ val lookup_type_declaration :
 val lookup_document_symbols :
   document_state -> Linol_lwt.SymbolInformation.t list
 
+val explain_plugin_available : bool option ref
+
 val lookup_lenses : document_state -> Linol_lwt.CodeLens.t list option
 
 val exceptions_at :

--- a/server/src/server.ml
+++ b/server/src/server.ml
@@ -929,11 +929,23 @@ class catala_lsp_server =
         let all_symbols = DQ.lookup_document_symbols doc in
         Lwt.return_some (`SymbolInformation all_symbols)
 
-    method! on_req_code_lens ~notify_back:_ ~id:_ ~uri ~workDoneToken:_
+    method! on_req_code_lens ~notify_back ~id:_ ~uri ~workDoneToken:_
         ~partialResultToken:_ _doc_state : CodeLens.t list Lwt.t =
       let doc_id = Doc_id.of_lsp_uri uri in
       if should_ignore doc_id then Lwt.return_nil
       else
+        (* check explain plugin availability on first use *)
+        let* () =
+          match !DQ.explain_plugin_available with
+          | Some _ -> Lwt.return_unit
+          | None ->
+            let* available =
+              Utils.check_catala_plugin_availability ~notify_back
+                ~plugin:"explain"
+            in
+            DQ.explain_plugin_available := Some available;
+            Lwt.return_unit
+        in
         let* r =
           let*? doc, _ =
             retrieve_existing_document_when_ready doc_id server_state

--- a/server/src/utils.ml
+++ b/server/src/utils.ml
@@ -135,6 +135,41 @@ let check_catala_format_availability ~notify_back =
       | WSTOPPED _ -> Lwt.return_false)
     (fun _ -> Lwt.return_false)
 
+let lookup_catala_config_path (notify_back : Jsonrpc2.notify_back) =
+  let open Lwt.Syntax in
+  let r, w = Lwt.task () in
+  let param =
+    ConfigurationParams.create
+      ~items:[ConfigurationItem.create ~section:"catala.catalaPath" ()]
+  in
+  let* _req_id =
+    notify_back#send_request (WorkspaceConfiguration param) (fun e ->
+        match e with
+        | Ok (`String x :: _) ->
+          Lwt.wakeup w (Some x);
+          Lwt.return_unit
+        | Ok _ | Error _ ->
+          Lwt.wakeup w None;
+          Lwt.return_unit)
+  in
+  r
+
+let check_catala_plugin_availability ~notify_back ~plugin =
+  let open Lwt.Syntax in
+  Lwt.catch
+    (fun () ->
+      let* path_opt = lookup_catala_config_path notify_back in
+      let path = Option.value ~default:"catala" path_opt in
+      let path = if path = "" then "catala" else path in
+      let* status =
+        Lwt_process.exec ~stdout:`Dev_null ~stderr:`Dev_null
+          ("", [| path; plugin; "--help=plain" |])
+      in
+      match status with
+      | WEXITED 0 -> Lwt.return true
+      | WEXITED _ | WSIGNALED _ | WSTOPPED _ -> Lwt.return_false)
+    (fun _ -> Lwt.return_false)
+
 let write_string oc s =
   let open Lwt.Syntax in
   let rec inner nb_write pos len =

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,7 @@ import { initTests } from './extension/testAndCoverage';
 import type { CatalaEntrypoint } from './extension/lspRequests';
 import { listEntrypoints } from './extension/lspRequests';
 import { ScopeInputController } from './scope-editor/ScopeInputController';
+import { showExplainGraph } from './extension/explainGraphView';
 
 let client: LanguageClient;
 
@@ -115,6 +116,16 @@ async function runScope(args?: RunArgs): Promise<void> {
         ' '
       )
     );
+  }
+}
+
+async function explainScope(
+  context: vscode.ExtensionContext,
+  args?: RunArgs
+): Promise<void> {
+  args ??= await selectScope(false);
+  if (args) {
+    await showExplainGraph(context, args);
   }
 }
 
@@ -277,6 +288,12 @@ export async function activate(
     vscode.commands.registerCommand('catala.showExceptions', showExceptions),
     vscode.commands.registerCommand('catala.showExceptionsAtCursor', () =>
       showExceptionsAtCursor(client)
+    ),
+    vscode.commands.registerCommand('catala.explain', () =>
+      explainScope(context)
+    ),
+    vscode.commands.registerCommand('catala.explainScope', (args?: RunArgs) =>
+      explainScope(context, args)
     )
   );
 

--- a/src/extension/explainGraphView.ts
+++ b/src/extension/explainGraphView.ts
@@ -1,0 +1,171 @@
+import * as vscode from 'vscode';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as path from 'node:path';
+import { catalaPath, getCwd } from '../shared/util_client';
+import type { RunArgs } from '../shared/util_client';
+
+const execFileAsync = promisify(execFile);
+
+// stdout threshold for graphs (default is 1Mo).
+const MAX_DOT_BUFFER = 64 * 1024 * 1024;
+
+// custom URL scheme passed as `catala explain --url-base`, so node links point
+// to `<url-base>/<file><line-suffix>`
+const CATALA_OPEN_SCHEME = 'catala-open:';
+
+function parseCatalaOpenHref(
+  href: string | undefined
+): { file: string; line?: number } | null {
+  if (!href?.startsWith(CATALA_OPEN_SCHEME)) return null;
+  let rest = href.slice(CATALA_OPEN_SCHEME.length);
+  let line: number | undefined;
+  const m = /#L(\d+)$/.exec(rest);
+  if (m) {
+    line = Number.parseInt(m[1]);
+    rest = rest.slice(0, m.index);
+  }
+  const file = rest.replace(/^\//, '');
+  if (!file) return null;
+  return { file, line };
+}
+
+async function openSourceFile(
+  href: string,
+  cwd: string | undefined
+): Promise<void> {
+  const parsed = parseCatalaOpenHref(href);
+  if (!parsed) return;
+  const filePath =
+    path.isAbsolute(parsed.file) || !cwd
+      ? parsed.file
+      : path.join(cwd, parsed.file);
+  const line = parsed.line && parsed.line > 0 ? parsed.line - 1 : 0;
+  const position = new vscode.Position(line, 0);
+  try {
+    await vscode.window.showTextDocument(vscode.Uri.file(filePath), {
+      selection: new vscode.Range(position, position),
+      preview: false,
+    });
+  } catch {
+    vscode.window.showErrorMessage(`Catala explain: cannot open '${filePath}'`);
+  }
+}
+
+type PanelState = { panel: vscode.WebviewPanel; dot: string };
+const panels = new Map<string, PanelState>();
+
+function isDarkTheme(): boolean {
+  const kind = vscode.window.activeColorTheme.kind;
+  return (
+    kind === vscode.ColorThemeKind.Dark ||
+    kind === vscode.ColorThemeKind.HighContrast
+  );
+}
+
+async function computeDot(args: RunArgs): Promise<string> {
+  const { stdout } = await execFileAsync(
+    catalaPath,
+    [
+      'explain',
+      args.uri,
+      '--scope',
+      args.scope,
+      '--dot',
+      '--theme',
+      isDarkTheme() ? 'dark' : 'light',
+      '--url-base',
+      CATALA_OPEN_SCHEME,
+    ],
+    { cwd: getCwd(args.uri), maxBuffer: MAX_DOT_BUFFER }
+  );
+  return stdout;
+}
+
+function getHtmlForWebview(
+  context: vscode.ExtensionContext,
+  webview: vscode.Webview
+): string {
+  const scriptUri = webview.asWebviewUri(
+    vscode.Uri.joinPath(context.extensionUri, 'dist', 'ui.js')
+  );
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Catala Explain</title>
+  <style>
+    html, body { height: 100%; margin: 0; padding: 0; overflow: hidden; }
+    #graph { width: 100vw; height: 100vh; }
+    #graph svg { width: 100%; height: 100%; }
+    /* Shrink only the label text; node boxes keep their Graphviz layout size. */
+    #graph svg text { font-size: 10px; }
+    #error {
+      margin: 0;
+      padding: 1rem;
+      white-space: pre-wrap;
+      font-family: var(--vscode-editor-font-family), monospace;
+      color: var(--vscode-errorForeground);
+    }
+  </style>
+</head>
+<body>
+  <div id="graph"></div>
+  <pre id="error" hidden></pre>
+  <script src="${scriptUri}"></script>
+  <script>window.Ui.renderExplainGraph();</script>
+</body>
+</html>`;
+}
+
+export async function showExplainGraph(
+  context: vscode.ExtensionContext,
+  args: RunArgs
+): Promise<void> {
+  let dot: string;
+  try {
+    dot = await computeDot(args);
+  } catch (e) {
+    const err = e as { stderr?: string; message?: string };
+    const detail = err.stderr?.trim() ?? err.message;
+    vscode.window.showErrorMessage(
+      `Catala explain failed for scope '${args.scope}': ${detail}`
+    );
+    return;
+  }
+
+  const key = `${args.uri}::${args.scope}`;
+  const existing = panels.get(key);
+  if (existing) {
+    existing.dot = dot;
+    existing.panel.reveal(
+      existing.panel.viewColumn ?? vscode.ViewColumn.Active
+    );
+    void existing.panel.webview.postMessage({ kind: 'renderDot', dot });
+    return;
+  }
+
+  const panel = vscode.window.createWebviewPanel(
+    'catala.explainGraph',
+    `Explain: ${args.scope}`,
+    vscode.ViewColumn.Active,
+    { enableScripts: true, retainContextWhenHidden: true }
+  );
+  const state: PanelState = { panel, dot };
+  panels.set(key, state);
+  panel.onDidDispose(() => panels.delete(key));
+
+  const cwd = getCwd(args.uri);
+  panel.webview.onDidReceiveMessage(
+    (message: { kind?: string; href?: string }) => {
+      if (message?.kind === 'ready') {
+        void panel.webview.postMessage({ kind: 'renderDot', dot: state.dot });
+      } else if (message?.kind === 'openLink' && message.href) {
+        void openSourceFile(message.href, cwd);
+      }
+    }
+  );
+
+  panel.webview.html = getHtmlForWebview(context, panel.webview);
+}

--- a/src/uiEntryPoint.ts
+++ b/src/uiEntryPoint.ts
@@ -2,6 +2,7 @@ import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { writeUpMessage } from './generated/catala_types';
 import App, { InputApp } from './App';
+import { graphviz } from 'd3-graphviz';
 import './styles/index.css';
 import '../node_modules/@vscode/codicons/dist/codicon.css';
 
@@ -18,4 +19,45 @@ export function renderInputScopeUi(language: string, scopename: string): void {
   const root = createRoot(document.getElementById('root') as HTMLElement);
   root.render(createElement(InputApp, { language, vscode, scopename }));
   vscode.postMessage(writeUpMessage({ kind: 'Ready' }));
+}
+
+export function renderExplainGraph(): void {
+  const vscode = acquireVsCodeApi();
+  const errorEl = document.getElementById('error');
+
+  const renderer = graphviz('#graph', {
+    useWorker: false, // for wasm CSP
+    fit: true,
+    zoom: true,
+  });
+
+  // Intercept clicks on node links to open local source files
+  const graphEl = document.getElementById('graph');
+  graphEl?.addEventListener('click', (event: MouseEvent) => {
+    if (!(event.target instanceof Element)) return;
+    const anchor = event.target.closest('a');
+    if (!anchor) return;
+    const href =
+      anchor.getAttribute('xlink:href') ?? anchor.getAttribute('href');
+    if (!href) return;
+    event.preventDefault();
+    event.stopPropagation();
+    vscode.postMessage({ kind: 'openLink', href });
+  });
+
+  window.addEventListener('message', (event: MessageEvent) => {
+    const msg = event.data as { kind?: string; dot?: string };
+    if (msg?.kind !== 'renderDot' || typeof msg.dot !== 'string') return;
+    try {
+      if (errorEl) errorEl.hidden = true;
+      renderer.renderDot(msg.dot);
+    } catch (e) {
+      if (errorEl) {
+        errorEl.hidden = false;
+        errorEl.textContent = `Failed to render graph:\n${String(e)}`;
+      }
+    }
+  });
+
+  vscode.postMessage({ kind: 'ready' });
 }


### PR DESCRIPTION
Graphs from explain plugin in the vscode extension.
The creation and rendering of graphs is made available by the LSP server for test scopes.
The rendering is made by the d3-graphviz library.

To test: 
- rebuild the repo (`make`)
- refresh the vscode extension (F5 in vscode)
- open catala-examples folder in the new window
- open exmple_explication/apl_locatif.catala_fr
- for the last scope `Exemple1` click `? Explain`


