### PR TITLE
testcase run: pass --input over stdin to avoid Windows ENAMETOOLONG

### DIFF
--- a/src/test-case-editor/testCaseCompilerInterop.ts
+++ b/src/test-case-editor/testCaseCompilerInterop.ts
@@ -110,9 +110,12 @@ export function runTestScope(
    * (note that not all these questions are related to the `runTestScope` function,
    * these could be handled externally as well)
    */
-  const inputArgs = inputs
-    ? ['--input', JSON.stringify(writeTestInputs(inputs))]
-    : [];
+  // Pass the input over stdin (`--input=-`), not inline: large generated inputs
+  // (tens of KB) overflow the Windows command-line limit and fail with ENAMETOOLONG.
+  const inputJson = inputs
+    ? JSON.stringify(writeTestInputs(inputs))
+    : undefined;
+  const inputArgs = inputs ? ['--input=-'] : [];
   const args = [
     'testcase',
     'run',
@@ -137,7 +140,10 @@ export function runTestScope(
   }
   // Here we *do* want to fail on asserts, as we catch failures through
   // the `register_lsp_error_notifier` hook.
-  const execResult = execBinary(catalaPath, args, { ...(cwd && { cwd }) });
+  const execResult = execBinary(catalaPath, args, {
+    ...(cwd && { cwd }),
+    ...(inputJson !== undefined && { input: inputJson }),
+  });
   if (!execResult.ok) {
     window.showErrorMessage(execResult.stderr);
     return { kind: 'Error', value: execResult.stderr };


### PR DESCRIPTION
Running a test scope could fail on Windows with `spawnSync … cmd.exe ENAMETOOLONG`: `runTestScope` passed the input JSON inline as `--input <JSON>`, and for scopes with large generated inputs (e.g. an enum with hundreds of constructors) the command line exceeded the Windows limit (~32k for CreateProcess) — observed at 45,841 chars.

Fix: pass the input over stdin (`--input=-`) via `execBinary`'s existing `input` option, so the command line stays constant-size. No behaviour change for the no-inputs case.