### PR TITLE
Fix/windows vscode spawn

### DIFF
--- a/server/src/utils.ml
+++ b/server/src/utils.ml
@@ -110,7 +110,13 @@ let lookup_catala_format_config_path (notify_back : Jsonrpc2.notify_back) =
   let* _req_id =
     notify_back#send_request (WorkspaceConfiguration param) (fun e ->
         match e with
-        | Ok (`String x :: _) ->
+        | Ok (`String x :: _) when x <> "" ->
+          (* An explicit non-empty path wins. VS Code reports an *unset*
+             `catala.catalaFormatPath` as an empty string (its schema default),
+             not null, so a bare `Some x` would hand `""` to callers: the
+             availability probe builds argv [|""|] and fails to spawn, wrongly
+             reporting formatting as unavailable even though it works. Treat ""
+             as "not configured" (None) so callers fall back to "catala-format". *)
           Lwt.wakeup w (Some x);
           Lwt.return_unit
         | Ok _ | Error _ ->

--- a/server/src/utils.ml
+++ b/server/src/utils.ml
@@ -111,12 +111,9 @@ let lookup_catala_format_config_path (notify_back : Jsonrpc2.notify_back) =
     notify_back#send_request (WorkspaceConfiguration param) (fun e ->
         match e with
         | Ok (`String x :: _) when x <> "" ->
-          (* An explicit non-empty path wins. VS Code reports an *unset*
-             `catala.catalaFormatPath` as an empty string (its schema default),
-             not null, so a bare `Some x` would hand `""` to callers: the
-             availability probe builds argv [|""|] and fails to spawn, wrongly
-             reporting formatting as unavailable even though it works. Treat ""
-             as "not configured" (None) so callers fall back to "catala-format". *)
+          (* VS Code reports an unset `catala.catalaFormatPath` as "" (schema
+             default), not null; treat "" as None so callers fall back to
+             "catala-format" instead of spawning argv [|""|]. *)
           Lwt.wakeup w (Some x);
           Lwt.return_unit
         | Ok _ | Error _ ->

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -185,7 +185,9 @@ export async function activate(
       const dap_path = resolveBinaryPath('catala-dap', context, 'main_dap.exe');
       if (dap_path) {
         const server = net.createServer((socket) => {
-          const adapter = spawn(dap_path, []);
+          const adapter = spawn(dap_path, [], {
+            shell: process.platform === 'win32',
+          });
           adapter.stdout.pipe(socket);
           socket.pipe(adapter.stdin);
           const output = vscode.window.createOutputChannel('Debugger Output');
@@ -230,7 +232,10 @@ export async function activate(
     getConfig('lspServerPath')
   );
   if (lsp_path) {
-    const run: Executable = { command: lsp_path };
+    const run: Executable = {
+      command: lsp_path,
+      options: process.platform === 'win32' ? { shell: true } : undefined,
+    };
     const serverOptions: ServerOptions = { run, debug: run };
     const clientOptions: LanguageClientOptions = {
       markdown: { isTrusted: true, supportHtml: true },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,9 @@ import { LanguageClient } from 'vscode-languageclient/node';
 import { TestCaseEditorProvider } from './extension/testCaseEditorProvider';
 import { logger } from './extension/logger';
 import * as net from 'net';
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
 import { spawn } from 'child_process';
 import {
   exceptionsViewProvider,
@@ -108,7 +111,22 @@ async function runScope(args?: RunArgs): Promise<void> {
     const termName = `${args.scope} execution`;
     vscode.window.terminals.find((t) => t.name === termName)?.dispose();
     const term = vscode.window.createTerminal({ name: termName, cwd });
-    const extra_args = inputs ? ['--input', `'${JSON.stringify(inputs)}'`] : [];
+    let extra_args: string[] = [];
+    if (inputs) {
+      if (process.platform === 'win32') {
+        // Inline JSON is mangled by cmd/PowerShell (single quotes are a
+        // POSIX-ism; the inner double quotes get stripped) and stdin isn't
+        // available for an interactive terminal, so write it to a temp file and
+        // pass --input=<file>. Stable per-scope name: overwritten each run, no
+        // accumulation.
+        const safe = args.scope.replace(/[^A-Za-z0-9_.-]/g, '_');
+        const tmp = path.join(os.tmpdir(), `catala-inputs-${safe}.json`);
+        fs.writeFileSync(tmp, JSON.stringify(inputs));
+        extra_args = [`--input="${tmp}"`];
+      } else {
+        extra_args = ['--input', `'${JSON.stringify(inputs)}'`];
+      }
+    }
     term.show();
     term.sendText(
       [clerkPath, 'run', args.uri, '--scope', args.scope, ...extra_args].join(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -160,8 +160,10 @@ async function debugScope(args?: RunArgs): Promise<void> {
   if (args) {
     const file = args.uri;
     const scope = args.scope;
+    // Uri.file, not Uri.parse: args.uri is an OS path (see runScope/getCwd);
+    // Uri.parse would read the Windows drive as a scheme and miss the folder.
     const workspace = vscode.workspace.getWorkspaceFolder(
-      vscode.Uri.parse(file)
+      vscode.Uri.file(file)
     );
     const config: vscode.DebugConfiguration = {
       type: 'catala-debugger',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -114,6 +114,12 @@ async function runScope(args?: RunArgs): Promise<void> {
       // (cmd.exe would need the opposite escaping).
       ...(process.platform === 'win32' && { shellPath: 'powershell.exe' }),
     });
+    // Single-quote a shell argument so spaces in paths survive. PowerShell
+    // escapes an embedded quote by doubling it; POSIX shells by '\''.
+    const sq = (s: string): string =>
+      process.platform === 'win32'
+        ? `'${s.replace(/'/g, "''")}'`
+        : `'${s.replace(/'/g, "'\\''")}'`;
     let extra_args: string[] = [];
     if (inputs) {
       const json = JSON.stringify(inputs);
@@ -127,9 +133,14 @@ async function runScope(args?: RunArgs): Promise<void> {
     }
     term.show();
     term.sendText(
-      [clerkPath, 'run', args.uri, '--scope', args.scope, ...extra_args].join(
-        ' '
-      )
+      [
+        clerkPath,
+        'run',
+        sq(args.uri),
+        '--scope',
+        args.scope,
+        ...extra_args,
+      ].join(' ')
     );
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,9 +8,6 @@ import { LanguageClient } from 'vscode-languageclient/node';
 import { TestCaseEditorProvider } from './extension/testCaseEditorProvider';
 import { logger } from './extension/logger';
 import * as net from 'net';
-import * as os from 'os';
-import * as fs from 'fs';
-import * as path from 'path';
 import { spawn } from 'child_process';
 import {
   exceptionsViewProvider,
@@ -110,22 +107,23 @@ async function runScope(args?: RunArgs): Promise<void> {
     const cwd = getCwd(args.uri);
     const termName = `${args.scope} execution`;
     vscode.window.terminals.find((t) => t.name === termName)?.dispose();
-    const term = vscode.window.createTerminal({ name: termName, cwd });
+    const term = vscode.window.createTerminal({
+      name: termName,
+      cwd,
+      // Pin PowerShell on Windows so the --input quoting below is deterministic
+      // (cmd.exe would need the opposite escaping).
+      ...(process.platform === 'win32' && { shellPath: 'powershell.exe' }),
+    });
     let extra_args: string[] = [];
     if (inputs) {
-      if (process.platform === 'win32') {
-        // Inline JSON is mangled by cmd/PowerShell (single quotes are a
-        // POSIX-ism; the inner double quotes get stripped) and stdin isn't
-        // available for an interactive terminal, so write it to a temp file and
-        // pass --input=<file>. Stable per-scope name: overwritten each run, no
-        // accumulation.
-        const safe = args.scope.replace(/[^A-Za-z0-9_.-]/g, '_');
-        const tmp = path.join(os.tmpdir(), `catala-inputs-${safe}.json`);
-        fs.writeFileSync(tmp, JSON.stringify(inputs));
-        extra_args = [`--input="${tmp}"`];
-      } else {
-        extra_args = ['--input', `'${JSON.stringify(inputs)}'`];
-      }
+      const json = JSON.stringify(inputs);
+      // Single-quote the JSON; on Windows (PowerShell) also backslash-escape the
+      // inner double quotes so they survive the native-command re-parse.
+      const quoted =
+        process.platform === 'win32'
+          ? `'${json.replace(/"/g, '\\"')}'`
+          : `'${json}'`;
+      extra_args = ['--input', quoted];
     }
     term.show();
     term.sendText(
@@ -178,8 +176,7 @@ async function debugScope(args?: RunArgs): Promise<void> {
   if (args) {
     const file = args.uri;
     const scope = args.scope;
-    // Uri.file, not Uri.parse: args.uri is an OS path (see runScope/getCwd);
-    // Uri.parse would read the Windows drive as a scheme and miss the folder.
+    // Uri.file, not Uri.parse: args.uri is an OS path.
     const workspace = vscode.workspace.getWorkspaceFolder(
       vscode.Uri.file(file)
     );

--- a/src/extension/exceptionsView.ts
+++ b/src/extension/exceptionsView.ts
@@ -259,7 +259,7 @@ export async function showExceptions(args: ExceptionsArgs): Promise<void> {
           variable,
           '--output-format=json',
         ],
-        { cwd }
+        { cwd, shell: process.platform === 'win32' }
       );
       proc.stdout.on('data', (data: Buffer) => {
         jsonOutput += data.toString();

--- a/src/extension/testAndCoverage.ts
+++ b/src/extension/testAndCoverage.ts
@@ -123,6 +123,7 @@ async function clerkRunTest(
   return new Promise((resolve) => {
     const proc = spawn(clerkPath, args, {
       ...(cwd && { cwd }),
+      shell: process.platform === 'win32',
     });
     cancellation.onCancellationRequested((_) => {
       proc.kill(2);

--- a/src/extension/testAndCoverage.ts
+++ b/src/extension/testAndCoverage.ts
@@ -326,8 +326,7 @@ function populateTestItems(
   const cwd = getCwd(path);
   if (cwd) {
     const cwd_uri = vscode.Uri.file(cwd);
-    // URI paths use '/' on every platform (Uri.file lowercases the drive and
-    // forward-slashes it), so split on '/', not path.sep (which is '\' on Windows).
+    // URI paths always use '/', even on Windows — not path.sep.
     const file_path = uri.path.replace(cwd_uri.path + '/', '').split('/');
     const first_id_uri = vscode.Uri.joinPath(cwd_uri, file_path[0]);
     const item: vscode.TestItem =
@@ -407,9 +406,7 @@ function updateTestItemWithClerkResult(
     const messages = scopeTest.errors.map((error) => {
       const msg = new vscode.TestMessage(error.message);
       if (error.location) {
-        // Uri.file, not Uri.parse: error.location.file is an OS path ("c:\\...")
-        // and Uri.parse would read the drive as a scheme, so VS Code fails to
-        // open the editor at the failure location.
+        // Uri.file, not Uri.parse: error.location.file is an OS path.
         msg.location = new vscode.Location(
           vscode.Uri.file(error.location.file),
           error.location.range
@@ -511,8 +508,7 @@ export async function initTests(
     const run: vscode.TestRun = ctrl.createTestRun(request);
     const testFiles =
       request.include
-        // fsPath, not path: clerk needs the OS path ("c:\\...") — uri.path is the
-        // URI form ("/c:/...") which clerk rejects ("no source file matching").
+        // fsPath, not path: clerk needs the OS path, not the URI form.
         ?.map(({ uri }) => uri?.fsPath)
         ?.filter((p) => p !== undefined) ?? [];
     const testsToRun = getAllTestsToRun(ctrl, request);

--- a/src/extension/testAndCoverage.ts
+++ b/src/extension/testAndCoverage.ts
@@ -506,7 +506,9 @@ export async function initTests(
     const run: vscode.TestRun = ctrl.createTestRun(request);
     const testFiles =
       request.include
-        ?.map(({ uri }) => uri?.path)
+        // fsPath, not path: clerk needs the OS path ("c:\\...") — uri.path is the
+        // URI form ("/c:/...") which clerk rejects ("no source file matching").
+        ?.map(({ uri }) => uri?.fsPath)
         ?.filter((p) => p !== undefined) ?? [];
     const testsToRun = getAllTestsToRun(ctrl, request);
     // Mark all tests as started before calling 'clerk test'

--- a/src/extension/testAndCoverage.ts
+++ b/src/extension/testAndCoverage.ts
@@ -1,7 +1,7 @@
 import type { LanguageClient } from 'vscode-languageclient/node';
 import * as vscode from 'vscode';
 import { spawn } from 'child_process';
-import { clerkPath, getCwd } from '../shared/util_client';
+import { clerkPath, getCwd, shellArg } from '../shared/util_client';
 import type { CatalaEntrypoint } from './lspRequests';
 import { listEntrypoints } from './lspRequests';
 import {
@@ -120,9 +120,10 @@ async function clerkRunTest(
     .concat(with_coverage ? ['--code-coverage'] : [])
     .concat(paths);
   return new Promise((resolve) => {
-    const proc = spawn(clerkPath, args, {
+    const useShell = process.platform === 'win32';
+    const proc = spawn(clerkPath, useShell ? args.map(shellArg) : args, {
       ...(cwd && { cwd }),
-      shell: process.platform === 'win32',
+      shell: useShell,
     });
     cancellation.onCancellationRequested((_) => {
       proc.kill(2);

--- a/src/extension/testAndCoverage.ts
+++ b/src/extension/testAndCoverage.ts
@@ -406,10 +406,15 @@ function updateTestItemWithClerkResult(
   } else {
     const messages = scopeTest.errors.map((error) => {
       const msg = new vscode.TestMessage(error.message);
-      msg.location = new vscode.Location(
-        vscode.Uri.parse(error.location.file),
-        error.location.range
-      );
+      if (error.location) {
+        // Uri.file, not Uri.parse: error.location.file is an OS path ("c:\\...")
+        // and Uri.parse would read the drive as a scheme, so VS Code fails to
+        // open the editor at the failure location.
+        msg.location = new vscode.Location(
+          vscode.Uri.file(error.location.file),
+          error.location.range
+        );
+      }
       return msg;
     });
     if (scopeTest.scope_name == 'compilation')

--- a/src/extension/testAndCoverage.ts
+++ b/src/extension/testAndCoverage.ts
@@ -1,7 +1,6 @@
 import type { LanguageClient } from 'vscode-languageclient/node';
 import * as vscode from 'vscode';
 import { spawn } from 'child_process';
-import { sep } from 'path';
 import { clerkPath, getCwd } from '../shared/util_client';
 import type { CatalaEntrypoint } from './lspRequests';
 import { listEntrypoints } from './lspRequests';
@@ -327,7 +326,9 @@ function populateTestItems(
   const cwd = getCwd(path);
   if (cwd) {
     const cwd_uri = vscode.Uri.file(cwd);
-    const file_path = uri.path.replace(cwd_uri.path + sep, '').split(sep);
+    // URI paths use '/' on every platform (Uri.file lowercases the drive and
+    // forward-slashes it), so split on '/', not path.sep (which is '\' on Windows).
+    const file_path = uri.path.replace(cwd_uri.path + '/', '').split('/');
     const first_id_uri = vscode.Uri.joinPath(cwd_uri, file_path[0]);
     const item: vscode.TestItem =
       ctrl.items.get(first_id_uri.path) ??

--- a/src/shared/util_client.ts
+++ b/src/shared/util_client.ts
@@ -94,9 +94,7 @@ logger.log(`catala command: ${catalaPath}`);
 logger.log(`clerk command: ${clerkPath}`);
 
 export function getCwd(bufferPath: string): string | undefined {
-  // Uri.file, not Uri.parse: bufferPath is an OS path, and Uri.parse would read
-  // the Windows drive ("c:\\...") as a URI scheme, yielding a bogus Uri that
-  // never matches a workspace folder.
+  // Uri.file, not Uri.parse: bufferPath is an OS path.
   return vscode.workspace.getWorkspaceFolder(vscode.Uri.file(bufferPath))?.uri
     ?.fsPath;
 }

--- a/src/shared/util_client.ts
+++ b/src/shared/util_client.ts
@@ -99,6 +99,13 @@ export function getCwd(bufferPath: string): string | undefined {
     ?.fsPath;
 }
 
+// The CLI helpers spawn with shell:true on Windows so a bare 'clerk'/'catala'
+// resolves via PATHEXT; cmd.exe then word-splits and Node does not quote argv,
+// so double-quote any argument containing whitespace (e.g. a spaced path).
+export function shellArg(a: string): string {
+  return process.platform === 'win32' && /\s/.test(a) ? `"${a}"` : a;
+}
+
 export function hasResourceUri(x: unknown): x is { resourceUri: vscode.Uri } {
   if (!x || typeof x !== 'object') return false;
   const ru = (x as { resourceUri?: unknown }).resourceUri;

--- a/src/shared/util_client.ts
+++ b/src/shared/util_client.ts
@@ -94,7 +94,10 @@ logger.log(`catala command: ${catalaPath}`);
 logger.log(`clerk command: ${clerkPath}`);
 
 export function getCwd(bufferPath: string): string | undefined {
-  return vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(bufferPath))?.uri
+  // Uri.file, not Uri.parse: bufferPath is an OS path, and Uri.parse would read
+  // the Windows drive ("c:\\...") as a URI scheme, yielding a bogus Uri that
+  // never matches a workspace folder.
+  return vscode.workspace.getWorkspaceFolder(vscode.Uri.file(bufferPath))?.uri
     ?.fsPath;
 }
 

--- a/src/test-case-editor/testCaseCompilerInterop.ts
+++ b/src/test-case-editor/testCaseCompilerInterop.ts
@@ -35,7 +35,11 @@ function execBinary(
   try {
     return {
       ok: true,
-      output: execFileSync(bin, args, { encoding: 'utf8', ...opts }),
+      output: execFileSync(bin, args, {
+        encoding: 'utf8',
+        shell: process.platform === 'win32',
+        ...opts,
+      }),
     };
   } catch (error) {
     const stderr = (error as SpawnSyncReturns<Buffer | string>).stderr;

--- a/src/test-case-editor/testCaseCompilerInterop.ts
+++ b/src/test-case-editor/testCaseCompilerInterop.ts
@@ -20,7 +20,7 @@ import path from 'path';
 import { clerkPath, catalaPath } from '../shared/util_client';
 
 function getCwd(bufferPath: string): string | undefined {
-  return workspace.getWorkspaceFolder(Uri.parse(bufferPath))?.uri?.fsPath;
+  return workspace.getWorkspaceFolder(Uri.file(bufferPath))?.uri?.fsPath;
 }
 
 type ExecOptions = { input?: string; cwd?: string };

--- a/src/test-case-editor/testCaseCompilerInterop.ts
+++ b/src/test-case-editor/testCaseCompilerInterop.ts
@@ -250,9 +250,7 @@ export function generate(
 export function serializeInputs(
   inputs: TestInputs
 ): { kind: 'Ok'; json: JSON } | { kind: 'Error'; message: string } {
-  // Pass the JSON over stdin (--input=-), not inline: with shell:true on Windows
-  // cmd.exe re-parses the argument and mangles the JSON's quotes ("argument is
-  // neither a file nor a valid JSON value"). Mirrors runTestScope/parseTestFile.
+  // JSON over stdin (--input=-): the Windows shell mangles it as an inline arg.
   const args = ['testcase', 'serialize-inputs', '--input=-'];
   const execResult = execBinary(catalaPath, args, {
     input: JSON.stringify(writeTestInputs(inputs)),

--- a/src/test-case-editor/testCaseCompilerInterop.ts
+++ b/src/test-case-editor/testCaseCompilerInterop.ts
@@ -17,7 +17,7 @@ import {
 import { logger } from '../extension/logger';
 import { Uri, window, workspace } from 'vscode';
 import path from 'path';
-import { clerkPath, catalaPath } from '../shared/util_client';
+import { clerkPath, catalaPath, shellArg } from '../shared/util_client';
 
 function getCwd(bufferPath: string): string | undefined {
   return workspace.getWorkspaceFolder(Uri.file(bufferPath))?.uri?.fsPath;
@@ -33,11 +33,12 @@ function execBinary(
 ): ExecResult {
   logger.log(`Running ${bin} ${args.join(' ')}`);
   try {
+    const useShell = process.platform === 'win32';
     return {
       ok: true,
-      output: execFileSync(bin, args, {
+      output: execFileSync(bin, useShell ? args.map(shellArg) : args, {
         encoding: 'utf8',
-        shell: process.platform === 'win32',
+        shell: useShell,
         ...opts,
       }),
     };

--- a/src/test-case-editor/testCaseCompilerInterop.ts
+++ b/src/test-case-editor/testCaseCompilerInterop.ts
@@ -250,13 +250,13 @@ export function generate(
 export function serializeInputs(
   inputs: TestInputs
 ): { kind: 'Ok'; json: JSON } | { kind: 'Error'; message: string } {
-  const args = [
-    'testcase',
-    'serialize-inputs',
-    '--input',
-    JSON.stringify(writeTestInputs(inputs)),
-  ];
-  const execResult = execBinary(catalaPath, args);
+  // Pass the JSON over stdin (--input=-), not inline: with shell:true on Windows
+  // cmd.exe re-parses the argument and mangles the JSON's quotes ("argument is
+  // neither a file nor a valid JSON value"). Mirrors runTestScope/parseTestFile.
+  const args = ['testcase', 'serialize-inputs', '--input=-'];
+  const execResult = execBinary(catalaPath, args, {
+    input: JSON.stringify(writeTestInputs(inputs)),
+  });
   if (!execResult.ok) {
     window.showErrorMessage(execResult.stderr);
     return { kind: 'Error', message: execResult.stderr };


### PR DESCRIPTION
Fixes related to the use of a native windows build / installer (with a little indirection: tools e.g. catala, catala-lsp, clerk are .cmd scripts that set the env and then delegate to the actual binary)