### PR TITLE
Miscellaneous improvements

### DIFF
--- a/server/src/document_processing.ml
+++ b/server/src/document_processing.ml
@@ -109,6 +109,110 @@ let lsp_errors_to_diag doc_id errors =
     (Doc_id.Map.singleton doc_id Range.Map.empty)
     errors
 
+let hash_local_context (ctx : Desugared.Name_resolution.context) : Hash.t =
+  let {
+    Desugared.Name_resolution.scopes;
+    topdefs;
+    structs;
+    enums;
+    abstract_types;
+    var_typs;
+    modules = _;
+    local;
+  } =
+    ctx
+  in
+  let strip = None in
+  let open Desugared.Name_resolution in
+  let open Hash in
+  let open Op in
+  let hash_typ = Type.hash ~strip in
+  let local_scopes =
+    ScopeName.Map.filter (fun sn _ -> ScopeName.path sn = []) scopes
+  in
+  let local_scopes_hash =
+    let hash_scope { scope_visibility; _ } =
+      (* we will get its real interface through [var_typs] *)
+      Hash.raw scope_visibility
+    in
+    ScopeName.Map.filter (fun sn _ -> ScopeName.path sn = []) scopes
+    |> map ScopeName.Map.fold (ScopeName.hash ~strip) hash_scope
+  in
+  let local_topdefs =
+    let hash_topdef (typ, vis) = Hash.raw (hash_typ typ, vis) in
+    TopdefName.Map.filter (fun td _ -> TopdefName.path td = []) topdefs
+    |> map TopdefName.Map.fold (TopdefName.hash ~strip) hash_topdef
+  in
+  let local_structs =
+    let hash_struct (struct_ctx, vis) =
+      map StructField.Map.fold StructField.hash hash_typ struct_ctx
+      % Hash.raw vis
+    in
+    StructName.Map.filter (fun sn _ -> StructName.path sn = []) structs
+    |> map StructName.Map.fold (StructName.hash ~strip) hash_struct
+  in
+  let local_enums =
+    let hash_enum (enum_ctx, vis) =
+      map EnumConstructor.Map.fold EnumConstructor.hash hash_typ enum_ctx
+      % Hash.raw vis
+    in
+    EnumName.Map.filter (fun en _ -> EnumName.path en = []) enums
+    |> map EnumName.Map.fold (EnumName.hash ~strip) hash_enum
+  in
+  let local_abs_typs =
+    AbstractType.Map.filter
+      (fun en _ -> AbstractType.path en = [])
+      abstract_types
+    |> map AbstractType.Map.fold (AbstractType.hash ~strip) raw
+  in
+  let local_var_typs =
+    let var_typs =
+      let local_scopes_vars =
+        ScopeName.Map.fold
+          (fun _sn { var_idmap; _ } s ->
+            Ident.Map.fold
+              (fun _id sv s ->
+                match sv with
+                | ScopeVar sv | SubScope (sv, _) -> ScopeVar.Set.add sv s)
+              var_idmap s)
+          local_scopes ScopeVar.Set.empty
+      in
+      ScopeVar.Map.filter
+        (fun sv _ -> ScopeVar.Set.mem sv local_scopes_vars)
+        var_typs
+    in
+    let hash_var_sig
+        {
+          var_sig_typ;
+          var_sig_is_condition = _;
+          var_sig_parameters;
+          var_sig_io;
+          var_sig_states_idmap = _;
+          var_sig_states_list;
+        } =
+      let hash_io
+          {
+            Surface.Ast.scope_decl_context_io_input;
+            scope_decl_context_io_output;
+          } =
+        raw (Mark.remove scope_decl_context_io_input)
+        % raw scope_decl_context_io_output
+      in
+      hash_typ var_sig_typ
+      % option (fun (l, _) -> list hash_typ (List.map snd l)) var_sig_parameters
+      % hash_io var_sig_io
+      % list StateName.hash var_sig_states_list
+    in
+    map ScopeVar.Map.fold ScopeVar.hash hash_var_sig var_typs
+  in
+  local_scopes_hash
+  % local_topdefs
+  % local_structs
+  % local_enums
+  % local_abs_typs
+  % local_var_typs
+  % map Ident.Map.fold Ident.hash ModuleName.hash local.used_modules
+
 let surface_to_scopelang
     ~on_error
     ~get_errors
@@ -199,11 +303,11 @@ let surface_to_scopelang
     let modules_content : Surface.Ast.module_content Uid.Module.Map.t =
       Uid.Module.Map.map (fun elt -> fst elt) modules
     in
-    let ctx, modules_contents = ctx, modules_content in
     let desugared =
-      Desugared.From_surface.translate_program ctx modules_contents surface
+      Desugared.From_surface.translate_program ctx modules_content surface
     in
     let prg = Desugared.Disambiguate.program desugared in
+    let sig_hash = hash_local_context ctx in
     let () = Desugared.Linting.lint_program prg in
     let exceptions_graphs =
       Scopelang.From_desugared.build_exceptions_graph prg
@@ -214,18 +318,24 @@ let surface_to_scopelang
     in
     let jump_table =
       lazy
-        (Jump_table.populate options.input_src ctx modules_contents surface prg)
+        (Jump_table.populate options.input_src ctx modules_content surface prg)
     in
     let used_modules : ModuleName.t File.Map.t =
       Ident.Map.bindings mod_uses |> File.Map.of_list
     in
+    let r =
+      {
+        Server_state.surface;
+        desugared;
+        sig_hash;
+        prg;
+        used_modules;
+        jump_table;
+      }
+    in
     match process_pending_errors ~on_error () with
-    | Error () ->
-      Partial
-        ( lsp_errors_to_diag doc_id (get_errors ()),
-          { Server_state.surface; desugared; prg; used_modules; jump_table } )
-    | Ok () ->
-      k { Server_state.surface; desugared; prg; used_modules; jump_table })
+    | Error () -> Partial (lsp_errors_to_diag doc_id (get_errors ()), r)
+    | Ok () -> k r)
 
 let process
     ~(resolve_file_content : string -> string Global.input_src)

--- a/server/src/server.ml
+++ b/server/src/server.ml
@@ -507,8 +507,25 @@ class catala_lsp_server =
         @@ fun () -> process_saved_file ~notify_back server_state doc_id
 
     method on_notif_doc_did_open ~notify_back d ~content:_ =
+      let* () = server_initialized in
       let doc_id = Doc_id.of_lsp_uri d.uri in
-      self#process_saved_document ~notify_back doc_id
+      if should_ignore doc_id then Lwt.return_unit
+      else
+        protect_project_not_found
+        @@ fun () ->
+        St.use_and_update server_state
+        @@ fun ({ open_documents; _ } as sstate) ->
+        if Doc_id.Map.mem doc_id open_documents then
+          (* Document exists: it should have been processed, do nothing. *)
+          Lwt.return sstate
+        else
+          let new_state = unlocked_process_file St.Saved doc_id sstate in
+          let* () =
+            unlocked_send_all_diagnostics ~doc_id ~notify_back new_state
+          in
+          (* Invalidate the cache *)
+          Server_state.unload_module_content new_state doc_id;
+          Lwt.return new_state
 
     method private document_changed ~notify_back ~new_contents doc_id =
       let* () = server_initialized in
@@ -592,11 +609,8 @@ class catala_lsp_server =
         (fun { FileEvent.uri; type_ } ->
           let doc_id = Doc_id.of_lsp_uri uri in
           match type_ with
-          | Created -> self#process_saved_document ~notify_back doc_id
-          | Changed -> self#process_saved_document ~notify_back doc_id
-          | Deleted ->
-            let* () = self#on_doc_delete ~notify_back doc_id in
-            self#on_doc_did_close ~notify_back doc_id)
+          | Created | Changed -> self#process_saved_document ~notify_back doc_id
+          | Deleted -> self#on_doc_delete ~notify_back doc_id)
         changes
 
     method private scan_project ~(notify_back : Jsonrpc2.notify_back)
@@ -884,19 +898,9 @@ class catala_lsp_server =
           Format.kasprintf Lwt.fail_with "Unknown LSP request received: %s" meth
         | _ -> super#on_request_unhandled ~notify_back ~id r
 
-    method private on_doc_did_close ~notify_back:_ (doc_id : Doc_id.t) =
-      let* () = server_initialized in
-      if should_ignore doc_id then Lwt.return_unit
-      else
-        St.use_and_update server_state
-        @@ fun { projects; open_documents; module_cache; diagnostics } ->
-        let open_documents = Doc_id.Map.remove doc_id open_documents in
-        let diagnostics = Doc_id.Map.remove doc_id diagnostics in
-        Lwt.return { St.projects; open_documents; module_cache; diagnostics }
-
-    method on_notif_doc_did_close ~notify_back d =
-      let* () = server_initialized in
-      self#on_doc_did_close ~notify_back (Doc_id.of_lsp_uri d.uri)
+    method on_notif_doc_did_close ~notify_back:_ _d =
+      (* Do nothing, we update documents through other requests *)
+      Lwt.return_unit
 
     method! on_req_completion ~notify_back:_ ~id:_ ~uri ~pos ~ctx:_
         ~workDoneToken:_ ~partialResultToken:_ doc_state =

--- a/server/src/server.ml
+++ b/server/src/server.ml
@@ -573,8 +573,14 @@ class catala_lsp_server =
               (fun _doc_id new_diag _ -> Some new_diag)
               new_diagnostics existing_diagnostics
           in
+          let new_open_documents = Doc_id.Map.remove doc_id open_documents in
           let new_state =
-            { St.projects; open_documents; module_cache; diagnostics }
+            {
+              St.projects;
+              open_documents = new_open_documents;
+              module_cache;
+              diagnostics;
+            }
           in
           let* () = unlocked_send_all_diagnostics ~notify_back new_state in
           Lwt.return new_state

--- a/server/src/server.ml
+++ b/server/src/server.ml
@@ -583,45 +583,106 @@ class catala_lsp_server =
             self#on_doc_did_close ~notify_back doc_id)
         changes
 
-    method private scan_project ~notify_back
+    method private scan_project ~(notify_back : Jsonrpc2.notify_back)
         ({ St.projects; open_documents; module_cache; diagnostics = _ } as
          sstate) =
-      let diagnostics, open_documents =
+      let* progress =
+        let w, r = Lwt.wait () in
+        let init_token = `String "init_progress" in
+        let* _req_id =
+          notify_back#send_request
+            (WorkDoneProgressCreate
+               (WorkDoneProgressCreateParams.create ~token:init_token))
+            (function
+              | Ok () ->
+                let notify_progress tok =
+                  notify_back#send_notification
+                    (Server_notification.WorkDoneProgress
+                       { token = init_token; value = tok })
+                in
+                Lwt.wakeup r (Some notify_progress);
+                Lwt.return_unit
+              | Error _r ->
+                Log.warn (fun m ->
+                    m "could not setup scanning project progress");
+                Lwt.wakeup r None;
+                Lwt.return_unit)
+        in
+        let* k = w in
+        match k with
+        | None -> Lwt.return (fun _ -> Lwt.return_unit)
+        | Some k -> Lwt.return k
+      in
+      let nb_files =
         Projects.Projects.fold
-          (fun project documents ->
+          (fun project acc -> Doc_id.Map.cardinal project.project_files + acc)
+          projects 0
+      in
+      let* () =
+        let begin_token =
+          WorkDoneProgressBegin.create ~cancellable:false
+            ~title:"Catala project scan" ~percentage:100 ()
+        in
+        progress (Progress.Begin begin_token)
+      in
+      let* _, (diagnostics, open_documents) =
+        Projects.Projects.fold
+          (fun project acc ->
             Doc_id.Map.fold
-              (fun doc_id _ (diagnostics, documents) ->
-                if Projects.is_an_included_file doc_id project then
-                  (* We do not consider included files *)
-                  diagnostics, documents
-                else
-                  (* Affected files are necessarily present in the project *)
-                  let project_file =
-                    Option.get @@ Projects.find_file_in_project doc_id project
-                  in
-                  let document =
-                    match Doc_id.Map.find_opt doc_id documents with
-                    | None ->
-                      St.make_document St.Saved doc_id project project_file
-                    | Some document -> document
-                  in
-                  let _is_valid, document, document_diagnostics =
-                    let get_module_content =
-                      Server_state.get_module_content sstate
+              (fun doc_id _ r ->
+                let* n, (diagnostics, documents) = r in
+                let* () =
+                  let progress_token =
+                    let percentage =
+                      Float.round (100. *. (float (succ n) /. float nb_files))
+                      |> int_of_float
+                      |> min 99
                     in
-                    unlocked_process_document ~get_module_content document
-                      open_documents
+                    WorkDoneProgressReport.create ~cancellable:false
+                      ~message:
+                        (Format.asprintf "%d%% %a" percentage Doc_id.format
+                           doc_id)
+                      ~percentage ()
                   in
-                  let new_diagnostics =
-                    merge_diags document_diagnostics diagnostics
-                  in
-                  new_diagnostics, Doc_id.Map.add doc_id document documents)
-              project.project_files documents)
+                  progress (Report progress_token)
+                in
+                let acc =
+                  if Projects.is_an_included_file doc_id project then
+                    (* We do not consider included files *)
+                    diagnostics, documents
+                  else
+                    (* Affected files are necessarily present in the project *)
+                    let project_file =
+                      Option.get @@ Projects.find_file_in_project doc_id project
+                    in
+                    let document =
+                      match Doc_id.Map.find_opt doc_id documents with
+                      | None ->
+                        St.make_document St.Saved doc_id project project_file
+                      | Some document -> document
+                    in
+                    let _is_valid, document, document_diagnostics =
+                      let get_module_content =
+                        Server_state.get_module_content sstate
+                      in
+                      unlocked_process_document ~get_module_content document
+                        open_documents
+                    in
+                    let new_diagnostics =
+                      merge_diags document_diagnostics diagnostics
+                    in
+                    new_diagnostics, Doc_id.Map.add doc_id document documents
+                in
+                Lwt.return (succ n, acc))
+              project.project_files acc)
           projects
-          (Doc_id.Map.empty, open_documents)
+          (Lwt.return (0, (Doc_id.Map.empty, open_documents)))
       in
       let sstate = { St.projects; open_documents; module_cache; diagnostics } in
       let* () = unlocked_send_all_diagnostics ~notify_back sstate in
+      let* () =
+        progress (End (WorkDoneProgressEnd.create ~message:"Scanning done" ()))
+      in
       Lwt.return sstate
 
     method! on_notification_unhandled ~notify_back (n : Client_notification.t) =

--- a/server/src/server.ml
+++ b/server/src/server.ml
@@ -490,6 +490,7 @@ class catala_lsp_server =
 
     method private process_saved_document
         ~(notify_back : Linol_lwt.Jsonrpc2.notify_back) (doc_id : Doc_id.t) =
+      let* () = server_initialized in
       if should_ignore doc_id then Lwt.return_unit
       else
         protect_project_not_found
@@ -500,6 +501,7 @@ class catala_lsp_server =
       self#process_saved_document ~notify_back doc_id
 
     method private document_changed ~notify_back ~new_contents doc_id =
+      let* () = server_initialized in
       if should_ignore doc_id then Lwt.return_unit
       else
         protect_project_not_found
@@ -520,13 +522,16 @@ class catala_lsp_server =
     method on_notif_doc_did_change ~notify_back d
         (_c : TextDocumentContentChangeEvent.t list) ~old_content:_
         ~new_content:new_contents =
+      let* () = server_initialized in
       self#document_changed ~notify_back ~new_contents (Doc_id.of_lsp_uri d.uri)
 
     method! on_notif_doc_did_save ~notify_back d =
+      let* () = server_initialized in
       let doc_id = Doc_id.of_lsp_uri d.textDocument.uri in
       self#process_saved_document ~notify_back doc_id
 
     method private on_doc_delete ~notify_back (doc_id : Doc_id.doc_id) =
+      let* () = server_initialized in
       if should_ignore doc_id then Lwt.return_unit
       else
         protect_project_not_found
@@ -565,6 +570,7 @@ class catala_lsp_server =
           Lwt.return new_state
 
     method private on_notif_did_change_watched_files ~notify_back changes =
+      let* () = server_initialized in
       (* Triggers even on save.. *)
       Lwt_list.iter_p
         (fun { FileEvent.uri; type_ } ->
@@ -802,6 +808,7 @@ class catala_lsp_server =
         | _ -> super#on_request_unhandled ~notify_back ~id r
 
     method private on_doc_did_close ~notify_back:_ (doc_id : Doc_id.t) =
+      let* () = server_initialized in
       if should_ignore doc_id then Lwt.return_unit
       else
         St.use_and_update server_state
@@ -811,10 +818,12 @@ class catala_lsp_server =
         Lwt.return { St.projects; open_documents; module_cache; diagnostics }
 
     method on_notif_doc_did_close ~notify_back d =
+      let* () = server_initialized in
       self#on_doc_did_close ~notify_back (Doc_id.of_lsp_uri d.uri)
 
     method! on_req_completion ~notify_back:_ ~id:_ ~uri ~pos ~ctx:_
         ~workDoneToken:_ ~partialResultToken:_ doc_state =
+      let* () = server_initialized in
       let doc_id = Doc_id.of_lsp_uri uri in
       if should_ignore doc_id then Lwt.return_none
       else
@@ -830,6 +839,7 @@ class catala_lsp_server =
 
     method! on_req_definition ~notify_back:_ ~id:_ ~uri ~pos ~workDoneToken:_
         ~partialResultToken:_ _doc_state =
+      let* () = server_initialized in
       let doc_id = Doc_id.of_lsp_uri uri in
       if should_ignore doc_id then Lwt.return_none
       else
@@ -851,6 +861,7 @@ class catala_lsp_server =
 
     method private on_req_declaration ~notify_back:_ ~(uri : Uri0.t)
         ~(pos : Position.t) () : Locations.t option t =
+      let* () = server_initialized in
       let doc_id = Doc_id.of_lsp_uri uri in
       if should_ignore doc_id then Lwt.return_none
       else
@@ -870,6 +881,7 @@ class catala_lsp_server =
 
     method private on_req_references ~notify_back:_ ~(uri : Uri0.t)
         ~(pos : Position.t) () : Location.t list option Lwt.t =
+      let* () = server_initialized in
       let doc_id = Doc_id.of_lsp_uri uri in
       if should_ignore doc_id then Lwt.return_none
       else
@@ -888,6 +900,7 @@ class catala_lsp_server =
 
     method! on_req_hover ~notify_back:_ ~id:_ ~uri ~pos ~workDoneToken:_
         _doc_state : Hover.t option Lwt.t =
+      let* () = server_initialized in
       let doc_id = Doc_id.of_lsp_uri uri in
       if should_ignore doc_id then Lwt.return_none
       else
@@ -904,6 +917,7 @@ class catala_lsp_server =
 
     method private on_req_type_definition ~notify_back:_ ~(uri : Uri0.t)
         ~(pos : Position.t) () : Locations.t option Lwt.t =
+      let* () = server_initialized in
       let doc_id = Doc_id.of_lsp_uri uri in
       if should_ignore doc_id then Lwt.return_none
       else
@@ -921,7 +935,7 @@ class catala_lsp_server =
         | `SymbolInformation of SymbolInformation.t list ]
         option
         t =
-      Log.info (fun m -> m "DOCUMENT SYMBOL REQUEST");
+      let* () = server_initialized in
       let doc_id = Doc_id.of_lsp_uri uri in
       if should_ignore doc_id then Lwt.return_none
       else
@@ -931,6 +945,7 @@ class catala_lsp_server =
 
     method! on_req_code_lens ~notify_back:_ ~id:_ ~uri ~workDoneToken:_
         ~partialResultToken:_ _doc_state : CodeLens.t list Lwt.t =
+      let* () = server_initialized in
       let doc_id = Doc_id.of_lsp_uri uri in
       if should_ignore doc_id then Lwt.return_nil
       else
@@ -944,6 +959,7 @@ class catala_lsp_server =
 
     method private on_req_document_formatting ~notify_back
         (params : DocumentFormattingParams.t) : TextEdit.t list option Lwt.t =
+      let* () = server_initialized in
       let doc_id = Doc_id.of_lsp_uri params.textDocument.uri in
       if should_ignore doc_id then Lwt.return_none
       else
@@ -978,6 +994,7 @@ class catala_lsp_server =
           textDocument : TextDocumentIdentifier.t;
           _;
         } : WorkspaceEdit.t Lwt.t =
+      let* () = server_initialized in
       let empty_response = WorkspaceEdit.create () in
       let doc_id = Doc_id.of_lsp_uri textDocument.uri in
       if should_ignore doc_id then Lwt.return empty_response

--- a/server/src/server.ml
+++ b/server/src/server.ml
@@ -216,8 +216,12 @@ let unlocked_process_document
       else false, document, diags
     end
     | Valid result ->
+      let last_saved_intf =
+        if document.buffer_state = Saved then Some result.sig_hash
+        else document.last_saved_intf
+      in
       ( true,
-        { document with last_valid_result = Some result },
+        { document with last_valid_result = Some result; last_saved_intf },
         (* We need to put an empty singleton in diags, otherwise the underlying
            mechanism doesn't update the previous error... *)
         Doc_id.Map.singleton document.document_id Range.Map.empty )
@@ -335,16 +339,17 @@ let unlocked_process_file
     ({ St.projects; open_documents; diagnostics; module_cache } as sstate) :
     St.server_state =
   let doc_errors, on_error = make_error_handler () in
-  let document, projects =
+  let document, projects, prev_sig_hash =
     Doc_id.Map.find_opt doc_id open_documents
     |> function
-    | Some document -> { document with buffer_state }, projects
+    | Some document ->
+      { document with buffer_state }, projects, document.last_saved_intf
     | None ->
       let (project_file, project), new_projects_opt =
         lookup_project ~on_error doc_id projects
       in
       let projects = Option.value ~default:projects new_projects_opt in
-      St.make_document buffer_state doc_id project project_file, projects
+      St.make_document buffer_state doc_id project project_file, projects, None
   in
   let is_valid, new_document, document_diagnostics =
     let get_module_content = Server_state.get_module_content sstate in
@@ -380,8 +385,13 @@ let unlocked_process_file
         merge_diags document_diagnostics
           (Doc_id.Map.of_list included_files_empty_diags) )
   in
+  let has_interface_changed =
+    match prev_sig_hash, new_document.last_saved_intf with
+    | Some h, Some h' -> h <> h'
+    | _ -> true
+  in
   let should_process_dependencies =
-    is_fully_saved && is_valid && !scan_project_config
+    is_fully_saved && is_valid && !scan_project_config && has_interface_changed
   in
   let new_server_state =
     (* Update server state with the new processed document : we will add updated

--- a/server/src/server_state.ml
+++ b/server/src/server_state.ml
@@ -22,6 +22,7 @@ open Catala_utils
 type valid_result = {
   surface : Surface.Ast.program;
   desugared : Desugared.Ast.program;
+  sig_hash : Hash.t;
   prg : typed Scopelang.Ast.program;
   used_modules : ModuleName.t File.Map.t;
   jump_table : Jump_table.t Lazy.t;
@@ -43,6 +44,7 @@ type document_state = {
   project_file : Projects.project_file;
   last_valid_result : valid_result option;
   last_result : processing_result option;
+  last_saved_intf : Hash.t option;
 }
 
 let make_document buffer_state (document_id : Doc_id.t) project project_file =
@@ -55,6 +57,7 @@ let make_document buffer_state (document_id : Doc_id.t) project project_file =
     project_file;
     last_valid_result = None;
     last_result = None;
+    last_saved_intf = None;
   }
 
 type module_cache = Surface.Ast.module_content Doc_id.Hashtbl.t
@@ -248,8 +251,7 @@ let lookup_module_content
     in
     H.replace module_cache doc_id r;
     r
-  | Some r ->
-    r
+  | Some r -> r
 
 let get_module_content server_state =
   lookup_module_content server_state.module_cache

--- a/server/src/server_state.mli
+++ b/server/src/server_state.mli
@@ -21,6 +21,7 @@ open Server_types
 type valid_result = {
   surface : Surface.Ast.program;
   desugared : Desugared.Ast.program;
+  sig_hash : Hash.t;
   prg : typed Scopelang.Ast.program;
   used_modules : ModuleName.t File.Map.t;
   jump_table : Jump_table.t Lazy.t;
@@ -42,6 +43,7 @@ type document_state = {
   project_file : Projects.project_file;
   last_valid_result : valid_result option;
   last_result : processing_result option;
+  last_saved_intf : Hash.t option;
 }
 
 val make_document :


### PR DESCRIPTION
This PR improves and/or fixes the following behaviors :
- Prevent LSP requests handing before the server is fully initialized, this generated some extra-work at the start-up where we requested the full list of tests which would trigger double validation instead of using a populated cache.  
- Added a progress wheel when booting up a project the notify users that the LSP is not stalled.
- Do not reprocess dependencies on document save when no changes occurred interface-wised. This prevents a lot of useless verification.  
- Actually remove deleted documents from the state's open documents map
- Do not try to validate a document each time a `{open|close}_document` is triggered. They still will be triggered if the document isn't present in the state. Vscode is very eager to open documents on code hovering which is very slow on large projects.