### PR TITLE
Fix module directive hovering

### DIFF
--- a/server/src/document_processing.ml
+++ b/server/src/document_processing.ml
@@ -317,8 +317,8 @@ let surface_to_scopelang
       |> Scopelang.Ast.type_program
     in
     let jump_table =
-      lazy
-        (Jump_table.populate options.input_src ctx modules_content surface prg)
+      let input_src = options.input_src in
+      lazy (Jump_table.populate input_src ctx modules_content surface prg)
     in
     let used_modules : ModuleName.t File.Map.t =
       Ident.Map.bindings mod_uses |> File.Map.of_list

--- a/server/src/jump_table.ml
+++ b/server/src/jump_table.ml
@@ -451,11 +451,7 @@ let traverse_scope_def tctx (rule : typed rule) m : PMap.acc =
     let var, pos_l = var in
     let name = ScopeVar.to_string var in
     let hash = hash_info (module ScopeVar) var in
-    let id =
-      match rule with
-      | ScopeVarDefinition _ -> Some (ScopeVar.id var)
-      | _ -> None
-    in
+    let id = Some (ScopeVar.id var) in
     let var = Definition { name; hash; typ; id } in
     let m = List.fold_right (fun p -> PMap.add p var) pos_l m in
     let m = traverse_typ tctx typ m in
@@ -646,9 +642,14 @@ let populate_modules
     (acc : PMap.acc) : PMap.acc * (ModuleName.t -> mjump) =
   let module C = Map.Make (String) in
   let convert_map =
+    let init_map =
+      match prog.program_module_name with
+      | None -> C.empty
+      | Some (m, _) -> C.singleton (ModuleName.to_string m) m
+    in
     ModuleName.Map.fold
       (fun mname _ acc -> C.add (ModuleName.to_string mname) mname acc)
-      prog.program_modules C.empty
+      prog.program_modules init_map
   in
   let process_module_use
       acc
@@ -701,10 +702,13 @@ let populate_modules
       try
         let name = String.to_ascii (Mark.remove module_name) in
         let mname = C.find name convert_map in
-        let mcontent = ModuleName.Map.find mname modules_contents in
+        let is_stdlib =
+          ModuleName.Map.find_opt mname modules_contents
+          |> Option.map (fun c -> c.Surface.Ast.module_is_stdlib)
+          |> Option.value ~default:false
+        in
         let interface =
-          Surface.Parser_driver.load_interface
-            ~is_stdlib:mcontent.module_is_stdlib input_src
+          Surface.Parser_driver.load_interface ~is_stdlib input_src
         in
         let pos = Mark.get module_name in
         let mjump = make_mjump mname interface in

--- a/server/src/type_printing.ml
+++ b/server/src/type_printing.ml
@@ -22,6 +22,11 @@ open Format
 let locale_s locale =
   match locale with `En -> "en" | `Fr -> "fr" | `Pl -> assert false
 
+let not_exposed_s = function
+  | `En -> "not exposed"
+  | `Fr -> "non exposé"
+  | `Pl -> "nie odsłonięta"
+
 let _for_all = function
   | `En -> "anything of type"
   | `Fr -> "n'importe quel de type"
@@ -370,14 +375,23 @@ let pp_module
 
      > Invariant: an interface shall only contain [*Decl] elements, or [Topdef]
      > elements with [topdef_expr = None] *)
-  let pp_code_block fmt code_item =
+  let pp_code_block fmt (code_item, (vis : visibility)) =
+    let pp_vis ppf =
+      if vis = Private then fprintf ppf " # %s" (not_exposed_s locale)
+    in
     match Mark.remove code_item with
     | ScopeDecl sdecl ->
-      fprintf fmt "%s %s" (scope_s locale) (Mark.remove sdecl.scope_decl_name)
+      fprintf fmt "%s %s%t" (scope_s locale)
+        (Mark.remove sdecl.scope_decl_name)
+        pp_vis
     | StructDecl sdecl ->
-      fprintf fmt "%s %s" (struct_s locale) (Mark.remove sdecl.struct_decl_name)
+      fprintf fmt "%s %s%t" (struct_s locale)
+        (Mark.remove sdecl.struct_decl_name)
+        pp_vis
     | EnumDecl edecl ->
-      fprintf fmt "%s %s" (enum_s locale) (Mark.remove edecl.enum_decl_name)
+      fprintf fmt "%s %s%t" (enum_s locale)
+        (Mark.remove edecl.enum_decl_name)
+        pp_vis
     | Topdef top_def -> (
       match
         TopdefName.Map.bindings ctx.ctx_topdefs
@@ -388,16 +402,18 @@ let pp_module
       with
       | None -> () (* ?? *)
       | Some (_, (topdef_typ, _)) ->
-        pp_topdef locale fmt (Mark.remove top_def.topdef_name, topdef_typ))
+        fprintf fmt "%a%t" (pp_topdef locale)
+          (Mark.remove top_def.topdef_name, topdef_typ)
+          pp_vis)
     | AbstractTypeDecl t ->
-      fprintf fmt "%s %s" (external_type_s locale) (Mark.remove t)
+      fprintf fmt "%s %s%t" (external_type_s locale) (Mark.remove t) pp_vis
     | ScopeUse _ -> ()
   in
   match mcontent.module_items with
   | Interface items ->
     fprintf fmt "@[<v>%a@]"
       (pp_print_list ~pp_sep:pp_print_space pp_code_block)
-      (List.map Mark.remove items)
+      items
   | Code (ls : law_structure list) ->
     let rec loop = function
       | [] -> ()
@@ -407,10 +423,10 @@ let pp_module
       | LawHeading (_, ls) :: t ->
         loop ls;
         loop t
-      | CodeBlock (cb, _, _) :: t ->
+      | CodeBlock (cb, _, vis) :: t ->
         fprintf fmt "@[<v>%a@]"
           (pp_print_list ~pp_sep:pp_print_space pp_code_block)
-          cb;
+          (List.map (fun item -> item, if vis then Public else Private) cb);
         loop t
     in
     loop ls

--- a/server/src/type_printing.ml
+++ b/server/src/type_printing.ml
@@ -437,6 +437,7 @@ let module_type
     fprintf ppf "%a@\n" (pp_module locale prg) module_content;
     if markdown then fprintf ppf "```"
   in
+  Format.pp_print_flush ppf ();
   Buffer.contents buf
 
 let typ_to_content ~markdown prg locale (kind : Jump_table.type_lookup) =


### PR DESCRIPTION
This PR fixes an issue where hovering a `> Module XXX` wouldn't give the type resumé.
Also, added a `# not exposed` comment on non-metadata components

Related image:
<img width="795" height="246" alt="image" src="https://github.com/user-attachments/assets/b286e3af-4ea3-4021-9b77-6dce1a71a761" />
